### PR TITLE
Global 예외처리 기반 마련 및 api 요청에 대한 응답 문구 포맷

### DIFF
--- a/src/main/java/yuquiz/common/api/SuccessRes.java
+++ b/src/main/java/yuquiz/common/api/SuccessRes.java
@@ -1,0 +1,2 @@
+package yuquiz.common.api;public class SuccessRes {
+}

--- a/src/main/java/yuquiz/common/api/SuccessRes.java
+++ b/src/main/java/yuquiz/common/api/SuccessRes.java
@@ -1,2 +1,21 @@
-package yuquiz.common.api;public class SuccessRes {
+package yuquiz.common.api;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class SuccessRes<T> {
+
+    private T response;
+
+    @Builder
+    private SuccessRes(T response) {
+        this.response = response;
+    }
+
+    public static <T> SuccessRes<T> from(T response) {
+        return SuccessRes.<T>builder()
+                .response(response)
+                .build();
+    }
 }

--- a/src/main/java/yuquiz/common/exception/CustomException.java
+++ b/src/main/java/yuquiz/common/exception/CustomException.java
@@ -1,0 +1,13 @@
+package yuquiz.common.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+
+    private final ExceptionCode exceptionCode;
+}
+

--- a/src/main/java/yuquiz/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/yuquiz/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,62 @@
+package yuquiz.common.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import yuquiz.common.exception.dto.ErrorRes;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+import yuquiz.common.exception.exceptionCode.GlobalExceptionCode;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    /* CustomHandler 에러 처리 */
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<?> customExceptionHandler(CustomException ex) {
+
+        ExceptionCode exceptionCode = ex.getExceptionCode();
+        ErrorRes errorRes = ErrorRes.fromEntity(exceptionCode);
+        log.error("Error occurred : {}, Stack trace: {}", ex.getMessage(), getCustomStackTrace(ex));
+        return ResponseEntity.status(errorRes.getStatus()).body(errorRes);
+    }
+
+    /* 유효성 검사 예외 처리 */
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<Map<String, String>> handleValidationException(MethodArgumentNotValidException ex) {
+
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : ex.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+        log.error("Error occurred : {}", errors);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+    }
+
+    /* 일반 예외 처리 */
+    @ExceptionHandler
+    protected ResponseEntity<?> customServerException(Exception ex) {
+
+        ExceptionCode exceptionCode = GlobalExceptionCode.INTERNAL_SERVER_ERROR;
+        ErrorRes errorRes = ErrorRes.fromEntity(exceptionCode);
+        log.error("Error occurred : {}, Stack trace: {}", ex.getMessage(), getCustomStackTrace(ex));
+        return ResponseEntity.status(errorRes.getStatus()).body(errorRes);
+    }
+
+    /* 오류 코드 5줄 불러오기 */
+    public String getCustomStackTrace(Exception ex) {
+        StackTraceElement[] stackTrace = ex.getStackTrace();
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < Math.min(stackTrace.length, 5); i++) {
+            sb.append(stackTrace[i].toString()).append("\n");
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/yuquiz/common/exception/dto/ErrorRes.java
+++ b/src/main/java/yuquiz/common/exception/dto/ErrorRes.java
@@ -1,0 +1,17 @@
+package yuquiz.common.exception.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@Getter
+@AllArgsConstructor
+public class ErrorRes {
+
+    private int status;
+    private String message;
+
+    public static ErrorRes fromEntity(ExceptionCode exceptionCode) {
+        return new ErrorRes(exceptionCode.getStatus(), exceptionCode.getMessage());
+    }
+}

--- a/src/main/java/yuquiz/common/exception/exceptionCode/ExceptionCode.java
+++ b/src/main/java/yuquiz/common/exception/exceptionCode/ExceptionCode.java
@@ -1,0 +1,7 @@
+package yuquiz.common.exception.exceptionCode;
+
+public interface ExceptionCode {
+
+    int getStatus();
+    String getMessage();
+}

--- a/src/main/java/yuquiz/common/exception/exceptionCode/GlobalExceptionCode.java
+++ b/src/main/java/yuquiz/common/exception/exceptionCode/GlobalExceptionCode.java
@@ -1,0 +1,23 @@
+package yuquiz.common.exception.exceptionCode;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum GlobalExceptionCode implements ExceptionCode {
+
+    // 서버 에러
+    INTERNAL_SERVER_ERROR(500, "서버 에러입니다. 서버 팀에 연락주세요.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}


### PR DESCRIPTION
## 개요
Global 예외처리 기반 마련 및. api 요청에 대한 응답 문구 포맷

## 구현 사항
 - Global 예외처리 기반 마련
 - Global 예외처리 기반 마련

## 기타
예외처리 같은 경우, global적인 예외처리는 GlobalExceptionCode에, 해당 domain에 대한 예외처리는 해당 예외처리 코드를 만들어 (ex. User라면 UserExceptionCode) 작성하시면 됩니다. 이번주에 만나면 다시 말씀 드리도록 하겠습니다.

아직 프로젝트가 만들어지지 않아 해당 프로젝트에서는 테스트를 못해보았고, 다른 프로젝트에서 실행 예시를 들고왔습니다.
![image](https://github.com/user-attachments/assets/eda360fc-b531-4f77-b5d6-7b38dcdd1550)
