### PR TITLE
feat: 퀴즈 생성, 수정, 삭제 구현

### DIFF
--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -1,0 +1,23 @@
+package yuquiz.domain.quiz.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.quiz.dto.QuizCreateReq;
+import yuquiz.domain.quiz.service.QuizService;
+
+import java.security.Principal;
+
+@RestController
+@RequestMapping("/api/v1/quizzes")
+@RequiredArgsConstructor
+public class QuizController {
+    private final QuizService quizService;
+    @PostMapping
+    public ResponseEntity<?> createQuiz(@RequestBody QuizCreateReq quizCreateReq, Principal principal) {
+        quizService.quizCreate(quizCreateReq,principal);
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("퀴즈 생성 성공."));
+    }
+}

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -4,10 +4,12 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.quiz.dto.QuizReq;
 import yuquiz.domain.quiz.service.QuizService;
+import yuquiz.security.auth.SecurityUserDetails;
 
 import java.security.Principal;
 
@@ -15,25 +17,27 @@ import java.security.Principal;
 @RequestMapping("/api/v1/quizzes")
 @RequiredArgsConstructor
 public class QuizController {
+
     private final QuizService quizService;
+
     @PostMapping
-    public ResponseEntity<?> createQuiz(@Valid  @RequestBody QuizReq quizReq, Principal principal) {
-        quizService.createQuiz(quizReq,principal);
+    public ResponseEntity<?> createQuiz(@Valid  @RequestBody QuizReq quizReq, @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        quizService.createQuiz(quizReq, userDetails.getId());
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("퀴즈 생성 성공."));
     }
 
-    @DeleteMapping
-    public ResponseEntity<?> deleteQuiz(@RequestParam(value = "quizId") Long quizId, Principal principal) {
-        quizService.deleteQuiz(quizId, principal);
+    @DeleteMapping("/{quizId}")
+    public ResponseEntity<?> deleteQuiz(@PathVariable(value = "quizId") Long quizId, @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        quizService.deleteQuiz(quizId, userDetails.getId());
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @PutMapping
+    @PutMapping("/{quizId}")
     public ResponseEntity<?> updateQuiz(
-            @RequestParam(value = "quizId") Long quizId,
+            @PathVariable(value = "quizId") Long quizId,
             @Valid @RequestBody QuizReq quizReq,
-            Principal principal) {
-        quizService.updateQuiz(quizId, quizReq, principal);
+            @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        quizService.updateQuiz(quizId, quizReq, userDetails.getId());
         return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("퀴즈 수정 성공."));
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -5,7 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
-import yuquiz.domain.quiz.dto.QuizCreateReq;
+import yuquiz.domain.quiz.dto.QuizReq;
 import yuquiz.domain.quiz.service.QuizService;
 
 import java.security.Principal;
@@ -16,8 +16,23 @@ import java.security.Principal;
 public class QuizController {
     private final QuizService quizService;
     @PostMapping
-    public ResponseEntity<?> createQuiz(@RequestBody QuizCreateReq quizCreateReq, Principal principal) {
-        quizService.quizCreate(quizCreateReq,principal);
+    public ResponseEntity<?> createQuiz(@RequestBody QuizReq quizReq, Principal principal) {
+        quizService.createQuiz(quizReq,principal);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("퀴즈 생성 성공."));
+    }
+
+    @DeleteMapping
+    public ResponseEntity<?> deleteQuiz(@RequestParam(value = "quizId") Long quizId, Principal principal) {
+        quizService.deleteQuiz(quizId, principal);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @PutMapping
+    public ResponseEntity<?> updateQuiz(
+            @RequestParam(value = "quizId") Long quizId,
+            @RequestBody QuizReq quizReq,
+            Principal principal) {
+        quizService.updateQuiz(quizId, quizReq, principal);
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("퀴즈 수정 성공."));
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -31,7 +31,7 @@ public class QuizController {
     @PutMapping
     public ResponseEntity<?> updateQuiz(
             @RequestParam(value = "quizId") Long quizId,
-            @RequestBody QuizReq quizReq,
+            @Valid @RequestBody QuizReq quizReq,
             Principal principal) {
         quizService.updateQuiz(quizId, quizReq, principal);
         return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("퀴즈 수정 성공."));

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -1,5 +1,6 @@
 package yuquiz.domain.quiz.controller;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -16,7 +17,7 @@ import java.security.Principal;
 public class QuizController {
     private final QuizService quizService;
     @PostMapping
-    public ResponseEntity<?> createQuiz(@RequestBody QuizReq quizReq, Principal principal) {
+    public ResponseEntity<?> createQuiz(@Valid  @RequestBody QuizReq quizReq, Principal principal) {
         quizService.createQuiz(quizReq,principal);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("퀴즈 생성 성공."));
     }

--- a/src/main/java/yuquiz/domain/quiz/dto/QuizCreateReq.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizCreateReq.java
@@ -1,0 +1,51 @@
+package yuquiz.domain.quiz.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import yuquiz.domain.quiz.entity.Quiz;
+import yuquiz.domain.quiz.entity.QuizType;
+import yuquiz.domain.subject.entity.Subject;
+import yuquiz.domain.user.entity.User;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class QuizCreateReq {
+    @NotBlank(message = "제목은 필수 입력입니다.")
+    String title;
+
+    @NotBlank(message = "질문은 필수 입력입니다.")
+    String question;
+
+    List<String> quizImg;
+
+    @NotBlank(message = "정답은 필수 입력입니다.")
+    String answer;
+
+    @NotBlank(message = "퀴즈 유형은 필수 입력입니다.")
+    QuizType quizType;
+
+    List<String> choices;
+
+    @NotBlank(message = "과목은 필수 입력입니다.")
+    Long subjectId;
+
+    Subject subject;
+
+    User writer;
+
+    public Quiz toEntity() {
+        return Quiz.builder()
+                .title(this.title)
+                .question(this.question)
+                .quizImgs(this.quizImg)
+                .answer(this.answer)
+                .quizType(this.quizType)
+                .choices(this.choices)
+                .writer(this.writer)
+                .subject(this.subject)
+                .build();
+    }
+}

--- a/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
@@ -1,6 +1,7 @@
 package yuquiz.domain.quiz.dto;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import yuquiz.domain.quiz.entity.Quiz;
@@ -24,12 +25,12 @@ public class QuizReq {
     @NotBlank(message = "정답은 필수 입력입니다.")
     String answer;
 
-    @NotBlank(message = "퀴즈 유형은 필수 입력입니다.")
+    @NotNull(message = "퀴즈 유형은 필수 입력입니다.")
     QuizType quizType;
 
     List<String> choices;
 
-    @NotBlank(message = "과목은 필수 입력입니다.")
+    @NotNull(message = "과목은 필수 입력입니다.")
     Long subjectId;
 
     Subject subject;

--- a/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 @Getter
 @Setter
-public class QuizCreateReq {
+public class QuizReq {
     @NotBlank(message = "제목은 필수 입력입니다.")
     String title;
 

--- a/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizReq.java
@@ -11,33 +11,32 @@ import yuquiz.domain.user.entity.User;
 
 import java.util.List;
 
-@Getter
-@Setter
-public class QuizReq {
+
+public record QuizReq (
     @NotBlank(message = "제목은 필수 입력입니다.")
-    String title;
+    String title,
 
     @NotBlank(message = "질문은 필수 입력입니다.")
-    String question;
+    String question,
 
-    List<String> quizImg;
+    List<String> quizImg,
 
     @NotBlank(message = "정답은 필수 입력입니다.")
-    String answer;
+    String answer,
 
     @NotNull(message = "퀴즈 유형은 필수 입력입니다.")
-    QuizType quizType;
+    QuizType quizType,
 
-    List<String> choices;
+    List<String> choices,
 
     @NotNull(message = "과목은 필수 입력입니다.")
-    Long subjectId;
+    Long subjectId,
 
-    Subject subject;
+    Subject subject,
 
-    User writer;
-
-    public Quiz toEntity() {
+    User writer
+){
+    public Quiz toEntity(User writer, Subject subject) {
         return Quiz.builder()
                 .title(this.title)
                 .question(this.question)
@@ -45,8 +44,9 @@ public class QuizReq {
                 .answer(this.answer)
                 .quizType(this.quizType)
                 .choices(this.choices)
-                .writer(this.writer)
-                .subject(this.subject)
+                .writer(writer)
+                .subject(subject)
                 .build();
     }
+
 }

--- a/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
+++ b/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
@@ -77,7 +77,7 @@ public class Quiz extends BaseTimeEntity {
 
     @Builder
     public Quiz(String title, String question, List<String> choices,
-                List<String> quizImgs, String answer, QuizType quizType) {
+                List<String> quizImgs, String answer, QuizType quizType, User writer, Subject subject) {
 
         this.title = title;
         this.question = question;
@@ -85,5 +85,7 @@ public class Quiz extends BaseTimeEntity {
         this.quizImgs = quizImgs;
         this.answer = answer;
         this.quizType = quizType;
+        this.writer = writer;
+        this.subject = subject;
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
+++ b/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.common.entity.BaseTimeEntity;
+import yuquiz.domain.quiz.dto.QuizReq;
 import yuquiz.domain.report.entity.Report;
 import yuquiz.domain.pinnedQuiz.entity.PinnedQuiz;
 import yuquiz.domain.quiz.converter.StringListConverter;
@@ -87,5 +88,15 @@ public class Quiz extends BaseTimeEntity {
         this.quizType = quizType;
         this.writer = writer;
         this.subject = subject;
+    }
+
+    public void update(QuizReq quizReq) {
+        this.title = quizReq.getTitle();
+        this.question = quizReq.getQuestion();
+        this.choices = quizReq.getChoices();
+        this.quizImgs = quizReq.getQuizImg();
+        this.answer = quizReq.getAnswer();
+        this.quizType = quizReq.getQuizType();
+        this.subject = quizReq.getSubject();
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
+++ b/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
@@ -90,13 +90,13 @@ public class Quiz extends BaseTimeEntity {
         this.subject = subject;
     }
 
-    public void update(QuizReq quizReq) {
-        this.title = quizReq.getTitle();
-        this.question = quizReq.getQuestion();
-        this.choices = quizReq.getChoices();
-        this.quizImgs = quizReq.getQuizImg();
-        this.answer = quizReq.getAnswer();
-        this.quizType = quizReq.getQuizType();
-        this.subject = quizReq.getSubject();
+    public void update(QuizReq quizReq, Subject subject) {
+        this.title = quizReq.title();
+        this.question = quizReq.question();
+        this.choices = quizReq.choices();
+        this.quizImgs = quizReq.quizImg();
+        this.answer = quizReq.answer();
+        this.quizType = quizReq.quizType();
+        this.subject = subject;
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/exception/QuizExceptionCode.java
+++ b/src/main/java/yuquiz/domain/quiz/exception/QuizExceptionCode.java
@@ -1,0 +1,24 @@
+package yuquiz.domain.quiz.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum QuizExceptionCode implements ExceptionCode {
+
+    INVALID_ID(404, "존재하지 않는 퀴즈입니다."),
+    UNAUTHORIZED_ACTION(403, "권한이 없습니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -4,8 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
-import yuquiz.domain.quiz.dto.QuizCreateReq;
+import yuquiz.domain.quiz.dto.QuizReq;
 import yuquiz.domain.quiz.entity.Quiz;
+import yuquiz.domain.quiz.exception.QuizExceptionCode;
 import yuquiz.domain.quiz.repository.QuizRepository;
 import yuquiz.domain.subject.entity.Subject;
 import yuquiz.domain.subject.exception.SubjectExceptionCode;
@@ -24,17 +25,48 @@ public class QuizService {
     private final SubjectRepository subjectRepository;
 
     @Transactional
-    public void quizCreate(QuizCreateReq quizCreateReq, Principal principal) {
-        User user = userRepository.findByUsername(principal.getName())
-                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERNAME));
+    public void createQuiz(QuizReq quizReq, Principal principal) {
+        User user = findUserByPrincipal(principal);
 
-        Subject subject = subjectRepository.findById(quizCreateReq.getSubjectId())
+        Subject subject = subjectRepository.findById(quizReq.getSubjectId())
                 .orElseThrow(() -> new CustomException(SubjectExceptionCode.INVALID_ID));
 
-        quizCreateReq.setWriter(user);
-        quizCreateReq.setSubject(subject);
+        quizReq.setWriter(user);
+        quizReq.setSubject(subject);
 
-        Quiz quiz = quizCreateReq.toEntity();
+        Quiz quiz = quizReq.toEntity();
         quizRepository.save(quiz);
+    }
+
+    @Transactional
+    public void deleteQuiz(Long quizId, Principal principal) {
+        Quiz quiz = findQuizByIdAndValidateUser(quizId, principal);
+        quizRepository.delete(quiz);
+    }
+
+    @Transactional
+    public void updateQuiz(Long quizId, QuizReq quizReq, Principal principal) {
+        Quiz quiz = findQuizByIdAndValidateUser(quizId, principal);
+
+        quizReq.setSubject(subjectRepository.findById(quizReq.getSubjectId())
+                .orElseThrow(() -> new CustomException(SubjectExceptionCode.INVALID_ID)));
+        quiz.update(quizReq);
+    }
+
+    private User findUserByPrincipal(Principal principal) {
+        return userRepository.findByUsername(principal.getName())
+                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERNAME));
+    }
+
+    private Quiz findQuizByIdAndValidateUser(Long quizId, Principal principal) {
+        User user = findUserByPrincipal(principal);
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizExceptionCode.INVALID_ID));
+
+        if (!quiz.getWriter().equals(user)) {
+            throw new CustomException(QuizExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        return quiz;
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -1,0 +1,40 @@
+package yuquiz.domain.quiz.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yuquiz.common.exception.CustomException;
+import yuquiz.domain.quiz.dto.QuizCreateReq;
+import yuquiz.domain.quiz.entity.Quiz;
+import yuquiz.domain.quiz.repository.QuizRepository;
+import yuquiz.domain.subject.entity.Subject;
+import yuquiz.domain.subject.exception.SubjectExceptionCode;
+import yuquiz.domain.subject.repository.SubjectRepository;
+import yuquiz.domain.user.entity.User;
+import yuquiz.domain.user.exception.UserExceptionCode;
+import yuquiz.domain.user.repository.UserRepository;
+
+import java.security.Principal;
+
+@Service
+@RequiredArgsConstructor
+public class QuizService {
+    private final QuizRepository quizRepository;
+    private final UserRepository userRepository;
+    private final SubjectRepository subjectRepository;
+
+    @Transactional
+    public void quizCreate(QuizCreateReq quizCreateReq, Principal principal) {
+        User user = userRepository.findByUsername(principal.getName())
+                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERNAME));
+
+        Subject subject = subjectRepository.findById(quizCreateReq.getSubjectId())
+                .orElseThrow(() -> new CustomException(SubjectExceptionCode.INVALID_ID));
+
+        quizCreateReq.setWriter(user);
+        quizCreateReq.setSubject(subject);
+
+        Quiz quiz = quizCreateReq.toEntity();
+        quizRepository.save(quiz);
+    }
+}

--- a/src/main/java/yuquiz/domain/subject/exception/SubjectExceptionCode.java
+++ b/src/main/java/yuquiz/domain/subject/exception/SubjectExceptionCode.java
@@ -1,0 +1,22 @@
+package yuquiz.domain.subject.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum SubjectExceptionCode implements ExceptionCode {
+    INVALID_ID(404, "존재하지 않는 과목입니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return 0;
+    }
+
+    @Override
+    public String getMessage() {
+        return null;
+    }
+}

--- a/src/main/java/yuquiz/domain/subject/exception/SubjectExceptionCode.java
+++ b/src/main/java/yuquiz/domain/subject/exception/SubjectExceptionCode.java
@@ -12,11 +12,11 @@ public enum SubjectExceptionCode implements ExceptionCode {
 
     @Override
     public int getStatus() {
-        return 0;
+        return this.status;
     }
 
     @Override
     public String getMessage() {
-        return null;
+        return this.message;
     }
 }

--- a/src/main/java/yuquiz/domain/user/exception/UserExceptionCode.java
+++ b/src/main/java/yuquiz/domain/user/exception/UserExceptionCode.java
@@ -7,7 +7,8 @@ import yuquiz.common.exception.exceptionCode.ExceptionCode;
 public enum UserExceptionCode implements ExceptionCode {
 
     // 로그인 에러
-    INVALID_USERNAME_AND_PASSWORD(404, "아이디 또는 비밀번호가 유효하지 않습니다.");
+    INVALID_USERNAME_AND_PASSWORD(404, "아이디 또는 비밀번호가 유효하지 않습니다."),
+    INVALID_USERNAME(404,"존재하지 않는 사용자입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/yuquiz/domain/user/exception/UserExceptionCode.java
+++ b/src/main/java/yuquiz/domain/user/exception/UserExceptionCode.java
@@ -8,7 +8,7 @@ public enum UserExceptionCode implements ExceptionCode {
 
     // 로그인 에러
     INVALID_USERNAME_AND_PASSWORD(404, "아이디 또는 비밀번호가 유효하지 않습니다."),
-    INVALID_USERNAME(404,"존재하지 않는 사용자입니다.");
+    INVALID_USERID(404,"존재하지 않는 사용자입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/yuquiz/security/auth/SecurityUserDetails.java
+++ b/src/main/java/yuquiz/security/auth/SecurityUserDetails.java
@@ -37,6 +37,10 @@ public class SecurityUserDetails implements UserDetails {
         return user.getUsername();
     }
 
+    public Long getId() {
+        return user.getId();
+    }
+
     @Override
     public boolean isEnabled() {
         throw new UnsupportedOperationException();


### PR DESCRIPTION
## 개요
퀴즈 생성, 수정, 삭제 구현

## 구현사항
* 퀴즈 생성 기능 
  * 퀴즈 생성 시 입력 검증
* 퀴즈 수정 기능
  * 퀴즈 수정 시 사용자 확인 후 작성자만 수정 가능
  * 입력 검증
* 퀴즈 삭제 기능
  * 퀴즈 삭제 시 사용자 확인 후 작성자만 삭제 가능

## 테스트
1. 퀴즈 생성 성공.
<img width="678" alt="image" src="https://github.com/user-attachments/assets/32d85b91-1599-43ab-a26d-c3e1ea0fe7cb">

2. 퀴즈 생성 실패 (입력 데이터 누락)
![image](https://github.com/user-attachments/assets/150111c6-8e5f-4db1-83e7-e17dc3551577)

3. 퀴즈 수정 성공
![image](https://github.com/user-attachments/assets/93782901-3419-42be-9bb4-63886ffdb5aa)

4. 퀴즈 수정 실패 (작성자 아님) 
![image](https://github.com/user-attachments/assets/d6690d8f-a026-49c0-8e1f-5fba63c361bb)

5. 퀴즈 수정 실패 (입력 데이터 누락)
<img width="672" alt="image" src="https://github.com/user-attachments/assets/9b8e002d-6899-4174-9f75-b9108f36f0dc">

6. 퀴즈 삭제 성공
보통 삭제할 때에는 삭제에 성공해서 해당 데이터가 이제 존재하지 않는다는 의미에서
HttpStatus를 204(No Content)를 많이 한다고 합니다.
저도 이번에 안 사실이라 혹시 아니라면 알려주시길 바랍니다.
![image](https://github.com/user-attachments/assets/f3684d70-a7ef-4a6b-88aa-b22e68725616)

7. 퀴즈 삭제 실패 (작성자 아님)
![image](https://github.com/user-attachments/assets/ac5d9210-d05e-4305-8a26-b0411f516f46)


