### PR TITLE
feat: 로그아웃시 사용자 accessToken 블랙리스트 추가

### DIFF
--- a/src/main/java/yuquiz/common/exception/exceptionCode/JwtExceptionCode.java
+++ b/src/main/java/yuquiz/common/exception/exceptionCode/JwtExceptionCode.java
@@ -7,7 +7,10 @@ public enum JwtExceptionCode implements ExceptionCode{
 
     ACCESS_TOKEN_EXPIRED(401, "Access Token이 만료되었습니다."),
     INVALID_ACCESS_TOKEN(401, "Access Token이 잘못되었습니다."),
-    REFRESH_TOKEN_NOT_FOUND(404, "RefreshToken이 존재하지 않습니다.");
+    BLACKLIST_ACCESS_TOKEN(401, "접근 불가한 AccessToken입니다."),
+
+    REFRESH_TOKEN_NOT_FOUND(404, "RefreshToken이 존재하지 않습니다."),
+    TOKEN_NOT_FOUND(404, "Token이 존재하지 않습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/yuquiz/common/jwt/filter/JwtExceptionFilter.java
+++ b/src/main/java/yuquiz/common/jwt/filter/JwtExceptionFilter.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.filter.OncePerRequestFilter;
+import yuquiz.common.exception.dto.ExceptionsRes;
 import yuquiz.common.exception.exceptionCode.ExceptionCode;
 import yuquiz.common.exception.exceptionCode.JwtExceptionCode;
 
@@ -34,7 +35,8 @@ public class JwtExceptionFilter extends OncePerRequestFilter {
     /* 예외 처리 */
     private void handleExceptionToken(HttpServletResponse response, ExceptionCode exceptionCode) throws IOException {
 
-        String messageBody = objectMapper.writeValueAsString(exceptionCode);
+        ExceptionsRes exceptionsRes = ExceptionsRes.of(exceptionCode.getStatus(), exceptionCode.getMessage());
+        String messageBody = objectMapper.writeValueAsString(exceptionsRes);
 
         log.error("Error occurred: {}", exceptionCode.getMessage());
 

--- a/src/main/java/yuquiz/common/utils/redis/RedisProperties.java
+++ b/src/main/java/yuquiz/common/utils/redis/RedisProperties.java
@@ -3,4 +3,5 @@ package yuquiz.common.utils.redis;
 public interface RedisProperties {
 
     String REFRESH_TOKEN_KEY_PREFIX = "refreshToken::";
+    String BLACKLIST_KEY_PREFIX = "blackList::";
 }

--- a/src/main/java/yuquiz/config/security/SecurityFilterConfig.java
+++ b/src/main/java/yuquiz/config/security/SecurityFilterConfig.java
@@ -8,18 +8,20 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import yuquiz.common.jwt.filter.JwtAuthenticationFilter;
 import yuquiz.common.jwt.filter.JwtExceptionFilter;
 import yuquiz.common.utils.jwt.JwtProvider;
+import yuquiz.security.token.blacklist.BlackListTokenService;
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityFilterConfig {
 
     private final UserDetailsService userDetailsService;
+    private final BlackListTokenService blackListTokenService;
     private final JwtProvider jwtProvider;
     private final ObjectMapper objectMapper;
 
     @Bean
     public JwtAuthenticationFilter jwtAuthenticationFilter() {
-        return new JwtAuthenticationFilter(userDetailsService, jwtProvider, objectMapper);
+        return new JwtAuthenticationFilter(userDetailsService, blackListTokenService, jwtProvider, objectMapper);
     }
 
     @Bean

--- a/src/main/java/yuquiz/domain/auth/controller/AuthController.java
+++ b/src/main/java/yuquiz/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import yuquiz.domain.auth.service.AuthService;
 import java.util.HashMap;
 import java.util.Map;
 
+import static yuquiz.common.utils.jwt.JwtProperties.ACCESS_HEADER_VALUE;
 import static yuquiz.common.utils.jwt.JwtProperties.REFRESH_COOKIE_VALUE;
 
 @RestController
@@ -50,14 +51,15 @@ public class AuthController {
 
     /* 로그아웃 */
     @GetMapping("/sign-out")
-    public ResponseEntity<?> signOut(@CookieValue(name = REFRESH_COOKIE_VALUE, required = false) String refreshToken,
+    public ResponseEntity<?> signOut(@RequestHeader(value = ACCESS_HEADER_VALUE, required = false) String accessToken,
+                                     @CookieValue(name = REFRESH_COOKIE_VALUE, required = false) String refreshToken,
                                      HttpServletResponse response) {
 
-        if (refreshToken == null) {
-            throw new CustomException(JwtExceptionCode.REFRESH_TOKEN_NOT_FOUND);
+        if (accessToken == null || refreshToken == null) {
+            throw new CustomException(JwtExceptionCode.TOKEN_NOT_FOUND);
         }
 
-        authService.signOut(refreshToken, response);
+        authService.signOut(accessToken, refreshToken, response);
 
         return ResponseEntity.ok(SuccessRes.from("로그아웃 되었습니다."));
     }

--- a/src/main/java/yuquiz/domain/auth/service/AuthService.java
+++ b/src/main/java/yuquiz/domain/auth/service/AuthService.java
@@ -13,6 +13,7 @@ import yuquiz.domain.auth.dto.TokenDto;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
+import yuquiz.security.token.blacklist.BlackListTokenService;
 import yuquiz.security.token.refresh.RefreshTokenService;
 
 import static yuquiz.common.utils.jwt.JwtProperties.REFRESH_COOKIE_VALUE;
@@ -25,6 +26,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final RefreshTokenService refreshTokenService;
+    private final BlackListTokenService blackListTokenService;
     private final CookieUtil cookieUtil;
     private final JwtProvider jwtProvider;
 
@@ -71,10 +73,13 @@ public class AuthService {
     }
 
     /* 로그아웃 */
-    public void signOut(String refreshToken, HttpServletResponse response) {
+    public void signOut(String accessTokenInHeader, String refreshToken, HttpServletResponse response) {
 
         cookieUtil.deleteCookie(REFRESH_COOKIE_VALUE, response);    // 쿠키값 삭제
 
         refreshTokenService.deleteRefreshToken(refreshToken);       // 로그아웃 시 redis에서 refreshToken 삭제
+
+        String accessToken = accessTokenInHeader.substring(TOKEN_PREFIX.length()).trim();
+        blackListTokenService.saveBlackList(accessToken);           // accessToken blackList에 저장
     }
 }

--- a/src/main/java/yuquiz/security/token/blacklist/BlackListTokenService.java
+++ b/src/main/java/yuquiz/security/token/blacklist/BlackListTokenService.java
@@ -1,0 +1,2 @@
+package yuquiz.security.token.blacklist;public class BlackListTokenService {
+}

--- a/src/main/java/yuquiz/security/token/blacklist/BlackListTokenService.java
+++ b/src/main/java/yuquiz/security/token/blacklist/BlackListTokenService.java
@@ -1,2 +1,32 @@
-package yuquiz.security.token.blacklist;public class BlackListTokenService {
+package yuquiz.security.token.blacklist;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import yuquiz.common.utils.redis.RedisUtil;
+
+import static yuquiz.common.utils.redis.RedisProperties.BLACKLIST_KEY_PREFIX;
+
+@Service
+@RequiredArgsConstructor
+public class BlackListTokenService {
+
+    private final RedisUtil redisUtil;
+
+    @Value("${token.blacklist.in-redis}")
+    private long BLACKLIST_EXPIRATION_TIME;
+
+    /* redis에 저장 */
+    public void saveBlackList(String accessToken) {
+
+        String key = BLACKLIST_KEY_PREFIX + accessToken;
+        redisUtil.set(key, accessToken);
+        redisUtil.expire(key, BLACKLIST_EXPIRATION_TIME);
+    }
+
+    /* 블랙리스트 확인. */
+    public boolean existsBlackListCheck(String accessToken) {
+        return redisUtil.existed(BLACKLIST_KEY_PREFIX + accessToken);
+    }
+
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,3 +32,5 @@ token:
   refresh:
     in-cookie: ${COOKIE_REFRESH_EXPIRATION:648000}
     in-redis: ${REDIS_REFRESH_EXPIRATION:648000}
+  blacklist:
+    in-redis: ${REDIS_BLACKLIST_EXPIRATION:3600}

--- a/src/test/java/yuquiz/auth/service/AuthServiceTest.java
+++ b/src/test/java/yuquiz/auth/service/AuthServiceTest.java
@@ -19,6 +19,7 @@ import yuquiz.domain.user.entity.Role;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
+import yuquiz.security.token.blacklist.BlackListTokenService;
 import yuquiz.security.token.refresh.RefreshTokenService;
 
 import java.lang.reflect.Field;
@@ -42,6 +43,9 @@ public class AuthServiceTest {
 
     @Mock
     private RefreshTokenService refreshTokenService;
+
+    @Mock
+    private BlackListTokenService blackListTokenService;
 
     @Mock
     private CookieUtil cookieUtil;
@@ -175,15 +179,19 @@ public class AuthServiceTest {
     void signOutTest() {
         // given
         String refreshToken = "refreshToken";
+        String accessToken = "Bearer accessToken";
+        String trimAccessToken = "accessToken";
 
         doNothing().when(cookieUtil).deleteCookie(REFRESH_COOKIE_VALUE, response);
         doNothing().when(refreshTokenService).deleteRefreshToken(refreshToken);
+        doNothing().when(blackListTokenService).saveBlackList(trimAccessToken);
 
         // when
-        authService.signOut(refreshToken, response);
+        authService.signOut(accessToken, refreshToken, response);
 
         // then
         verify(cookieUtil, times(1)).deleteCookie(REFRESH_COOKIE_VALUE, response);
         verify(refreshTokenService, times(1)).deleteRefreshToken(refreshToken);
+        verify(blackListTokenService, times(1)).saveBlackList(trimAccessToken);
     }
 }


### PR DESCRIPTION
## 개요
accessToken 같은 경우에는 설정한 유효시간이 지나기 전까지 유효하기에 사용이 지속적으로 가능합니다.
그렇게 되면, 사용자가 로그아웃을 하더라도 accessToken은 사용가능하기 때문에, 탈취를 당했다는 상황을 가정하면 좋지않은 결과가 일어날 것이라고 생각합니다.
그래서, accessToken을 blacklist시켜 redis에 accessToken 유효시간만큼 TTL을 저장시켜 넣어 놓는다면 accessToken의 안전성이 높아진다고 생각하여 아래와 같이 추가하였습니다.

## 구현 사항
 - 로그아웃시 accessToken blackList에 저장
 - jwt 인증과정에서 blacklist에 accessToken이 저장되어 있는지 검사

## 기타

1. 로그아웃 화면
![image](https://github.com/user-attachments/assets/e816ea04-5c1c-463f-b3bd-4cdbbe89cffd)

2. 로그아웃 후 accessToken으로 특정 api에 접속할 시 화면
![image](https://github.com/user-attachments/assets/37942fc8-fb28-4a7e-bd99-a7da6f91b3d0)
