### PR TITLE
feat: Swagger 설정 추기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,8 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.4.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/yuquiz/config/SwaggerConfig.java
+++ b/src/main/java/yuquiz/config/SwaggerConfig.java
@@ -1,0 +1,44 @@
+package yuquiz.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Arrays;
+
+@Configuration
+@OpenAPIDefinition(
+        info = @Info(title = "YU-Quiz",
+                description = "YU-Quiz API 명세서.",
+                version = "v1")
+)
+public class SwaggerConfig {
+    @Bean
+    public GroupedOpenApi openApi() {
+        String[] paths = {"/**"};
+
+        return GroupedOpenApi.builder()
+                .group("YU-Quiz v1")
+                .pathsToMatch(paths)
+                .build();
+    }
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP).scheme("bearer").bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER).name("Authorization");
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme))
+                .security(Arrays.asList(securityRequirement));
+    }
+
+}

--- a/src/main/java/yuquiz/domain/user/api/UserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/UserApi.java
@@ -1,2 +1,48 @@
-package yuquiz.domain.user.api;public interface UserApi {
+package yuquiz.domain.user.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+import yuquiz.domain.user.dto.SignUpReq;
+
+@Tag(name = "[사용자 API]", description = "사용자 관련 API")
+public interface UserApi {
+    @Operation(summary = "회원가입", description = "서비스 최초 이용시 회원가입을 하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원가입 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "response": "회원가입 성공."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "notBlank", value = """
+                                        {
+                                            "username": "아이디는 필수 입력 값입니다.",
+                                            "password": "비밀번호는 필수 입력 값입니다.",
+                                            "nickname": "닉네임은 필수 입력 값입니다.",
+                                            "email": "이메일은 필수 입력 값입니다.",
+                                            "majorName": "학과는 필수 선택 값입니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "patternError", value = """
+                                        {
+                                            "username": "아이디는 특수문자를 제외한 4~20자리여야 합니다.",
+                                            "nickname": "닉네임은 특수문자를 제외한 2~10자리여야 합니다.",
+                                            "password": "비밀번호는 8~16자 영문과 숫자를 사용하세요."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> signUp(@Valid @RequestBody SignUpReq signUpReq);
+
 }

--- a/src/main/java/yuquiz/domain/user/api/UserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/UserApi.java
@@ -1,0 +1,2 @@
+package yuquiz.domain.user.api;public interface UserApi {
+}

--- a/src/main/java/yuquiz/domain/user/controller/UserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/UserController.java
@@ -9,17 +9,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.user.api.UserApi;
 import yuquiz.domain.user.dto.SignUpReq;
 import yuquiz.domain.user.service.UserService;
 
 @RestController
 @RequestMapping("/api/v1/users")
 @RequiredArgsConstructor
-public class UserController {
+public class UserController implements UserApi {
 
     private final UserService userService;
 
     /* 회원가입 */
+    @Override
     @PostMapping
     public ResponseEntity<?> signUp(@Valid @RequestBody SignUpReq signUpReq) {
 

--- a/src/main/java/yuquiz/domain/user/dto/SignUpReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/SignUpReq.java
@@ -1,30 +1,38 @@
 package yuquiz.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import yuquiz.domain.user.entity.User;
 
+@Schema(name = "SignUpDto", description = "회원가입 요청 DTO")
 public record SignUpReq(
+        @Schema(description = "아이디", example = "test")
         @NotBlank(message = "아이디는 필수 입력입니다.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-z0-9-_]{4,20}$", message = "아이디는 특수문자를 제외한 4~20자리여야 합니다.")
         String username,
 
+        @Schema(description = "비밀번호", example = "password123")
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,16}", message = "비밀번호는 8~16자 영문과 숫자를 사용하세요.")
         String password,
 
+        @Schema(description = "닉네임", example = "테스터")
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
         String nickname,
 
+        @Schema(description = "아이디", example = "test@gmail.com")
         @NotBlank(message = "이메일은 필수 입력 값입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         String email,
 
+        @Schema(description = "학과", example = "컴퓨터공학과")
         @NotBlank(message = "학과는 필수 선택 값입니다.")
         String majorName,
 
+        @Schema(description = "이메일 수신 동의", example = "true")
         boolean agreeEmail
 ) {
     public User toEntity(String encodePassword) {


### PR DESCRIPTION
## 개요
프론트와의 편리한 협업을 위해 Swagger 작성

## 구현사항
 - Swagger 설정
 - 예시로 회원가입 Controller 스웨거 작성
 - 회원가입 관련 SignUpReq Dto 스웨거 작성

## 기타
 - Swagger 작성 시, 연관되어 있는 예외처리에 대한 내용도 모두 작성해주기를 바람.

 - Dto에 대해서 설명을 작성할 때, Response Dto는 작성하여도 스웨거에 뜨지 않음. 그래서, 컨트롤러에 스웨거 작성할 때, 반환에 대한 내용을 자세히 적어주어야 함.

 - SwaggerConfig 부분에서 아래 메서드에 작성한 코드는 헤더에 accessToken을 넣어두고 편리하게 사용하기 위함임.
``` java
@Bean
    public OpenAPI openAPI()
```