### PR TITLE
feat: User 조회, 업데이트, 삭제 구현

### DIFF
--- a/src/main/java/yuquiz/domain/user/api/UserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/UserApi.java
@@ -8,8 +8,11 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 import yuquiz.domain.user.dto.SignUpReq;
+import yuquiz.domain.user.dto.UserUpdateReq;
+import yuquiz.security.auth.SecurityUserDetails;
 
 @Tag(name = "[사용자 API]", description = "사용자 관련 API")
 public interface UserApi {
@@ -45,4 +48,88 @@ public interface UserApi {
     })
     ResponseEntity<?> signUp(@Valid @RequestBody SignUpReq signUpReq);
 
+    @Operation(summary = "사용자 정보 불러오기", description = "로그인한 사용자의 정보를 불러오는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "정보 불러오기 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "username": "test",
+                                            "nickname": "테스터",
+                                            "email": "test@naver.com",
+                                            "agreeEmail": true,
+                                            "majorName": "컴퓨터공학과"
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "유저 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "status": 404,
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getUserInfo(@AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "사용자 정보 업데이트", description = "로그인한 사용자의 정보를 업데이트 하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "회원 정보 수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "response": "회원 정보 수정 성공."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(name = "notBlank", value = """
+                                        {
+                                            "password": "비밀번호는 필수 입력 값입니다.",
+                                            "nickname": "닉네임은 필수 입력 값입니다.",
+                                            "majorName": "학과는 필수 선택 값입니다.",
+                                            "email": "이메일은 필수 입력 값입니다."
+                                        }
+                                    """),
+                            @ExampleObject(name = "patternError", value = """
+                                        {
+                                            "nickname": "닉네임은 특수문자를 제외한 2~10자리여야 합니다.",
+                                            "password": "비밀번호는 8~16자 영문과 숫자를 사용하세요."
+                                        }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "유저 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "status": 404,
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateUserInfo(@Valid @RequestBody UserUpdateReq updateReq,
+                                     @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "사용자 탈퇴", description = "로그인한 사용자가 서비스를 탈퇴하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 탈퇴 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "유저 존재하지 않음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                        {
+                                            "status": 404,
+                                            "message": "존재하지 않는 사용자입니다."
+                                        }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteUserInfo(@AuthenticationPrincipal SecurityUserDetails userDetails);
 }

--- a/src/main/java/yuquiz/domain/user/api/UserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/UserApi.java
@@ -118,17 +118,6 @@ public interface UserApi {
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자 탈퇴 성공",
                     content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                    """)
-                    })),
-            @ApiResponse(responseCode = "404", description = "유저 존재하지 않음",
-                    content = @Content(mediaType = "application/json", examples = {
-                            @ExampleObject(value = """
-                                        {
-                                            "status": 404,
-                                            "message": "존재하지 않는 사용자입니다."
-                                        }
-                                    """)
                     }))
     })
     ResponseEntity<?> deleteUserInfo(@AuthenticationPrincipal SecurityUserDetails userDetails);

--- a/src/main/java/yuquiz/domain/user/controller/UserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/UserController.java
@@ -4,14 +4,20 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.user.api.UserApi;
 import yuquiz.domain.user.dto.SignUpReq;
+import yuquiz.domain.user.dto.UserUpdateReq;
 import yuquiz.domain.user.service.UserService;
+import yuquiz.security.auth.SecurityUserDetails;
 
 @RestController
 @RequestMapping("/api/v1/users")
@@ -27,5 +33,32 @@ public class UserController implements UserApi {
 
         userService.createUser(signUpReq);
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("회원가입 성공."));
+    }
+
+    /* 사용자 정보 불러오기 */
+    @Override
+    @GetMapping("/my")
+    public ResponseEntity<?> getUserInfo(@AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(userService.getUserInfo(userDetails.getId()));
+    }
+
+    /* 사용자 정보 업데이트 */
+    @Override
+    @PutMapping("/my")
+    public ResponseEntity<?> updateUserInfo(@Valid @RequestBody UserUpdateReq updateReq,
+                                            @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        userService.updateUserInfo(updateReq, userDetails.getId());
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("회원 정보 수정 성공."));
+    }
+
+    /* 사용자 삭제 */
+    @Override
+    @DeleteMapping("/my")
+    public ResponseEntity<?> deleteUserInfo(@AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        userService.deleteUserInfo(userDetails.getId());
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/yuquiz/domain/user/dto/UserDetailsRes.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserDetailsRes.java
@@ -1,0 +1,21 @@
+package yuquiz.domain.user.dto;
+
+import yuquiz.domain.user.entity.User;
+
+public record UserDetailsRes(
+        String username,
+        String nickname,
+        String email,
+        boolean agreeEmail,
+        String majorName
+) {
+    public static UserDetailsRes fromEntity(User user) {
+        return new UserDetailsRes(
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.isAgreeEmail(),
+                user.getMajorName()
+        );
+    }
+}

--- a/src/main/java/yuquiz/domain/user/dto/UserUpdateReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserUpdateReq.java
@@ -1,0 +1,25 @@
+package yuquiz.domain.user.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record UserUpdateReq(
+        @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+        @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,16}", message = "비밀번호는 8~16자 영문과 숫자를 사용하세요.")
+        String password,
+
+        @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+        @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
+        String nickname,
+
+        @NotBlank(message = "이메일은 필수 입력 값입니다.")
+        @Email(message = "유효한 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "학과는 필수 선택 값입니다.")
+        String majorName,
+
+        boolean agreeEmail
+) {
+}

--- a/src/main/java/yuquiz/domain/user/dto/UserUpdateReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserUpdateReq.java
@@ -1,25 +1,32 @@
 package yuquiz.domain.user.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
+@Schema(name = "UserUpdateReq", description = "회원 정보 업데이트 요청 DTO")
 public record UserUpdateReq(
+        @Schema(description = "비밀번호", example = "password123")
         @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
         @Pattern(regexp = "(?=.*[0-9])(?=.*[a-zA-Z]).{8,16}", message = "비밀번호는 8~16자 영문과 숫자를 사용하세요.")
         String password,
 
+        @Schema(description = "닉네임", example = "테스터")
         @NotBlank(message = "닉네임은 필수 입력 값입니다.")
         @Pattern(regexp = "^[ㄱ-ㅎ가-힣a-zA-Z0-9-_]{2,10}$", message = "닉네임은 특수문자를 제외한 2~10자리여야 합니다.")
         String nickname,
 
+        @Schema(description = "아이디", example = "test@gmail.com")
         @NotBlank(message = "이메일은 필수 입력 값입니다.")
         @Email(message = "유효한 이메일 형식이 아닙니다.")
         String email,
 
+        @Schema(description = "학과", example = "컴퓨터공학과")
         @NotBlank(message = "학과는 필수 선택 값입니다.")
         String majorName,
 
+        @Schema(description = "이메일 수신 동의", example = "true")
         boolean agreeEmail
 ) {
 }

--- a/src/main/java/yuquiz/domain/user/entity/User.java
+++ b/src/main/java/yuquiz/domain/user/entity/User.java
@@ -1,7 +1,15 @@
 package yuquiz.domain.user.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -94,5 +102,14 @@ public class User extends BaseTimeEntity {
         this.majorName = majorName;
         this.agreeEmail = agreeEmail;
         this.role = role;
+    }
+
+    /* 사용자 업데이트 편의 메서드 */
+    public void updateUser(String password, String nickname, String email, boolean agreeEmail, String majorName) {
+        this.password = password;
+        this.nickname = nickname;
+        this.email = email;
+        this.agreeEmail = agreeEmail;
+        this.majorName = majorName;
     }
 }

--- a/src/main/java/yuquiz/domain/user/service/UserService.java
+++ b/src/main/java/yuquiz/domain/user/service/UserService.java
@@ -1,10 +1,16 @@
 package yuquiz.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import yuquiz.common.exception.CustomException;
 import yuquiz.domain.user.dto.SignUpReq;
+import yuquiz.domain.user.dto.UserDetailsRes;
+import yuquiz.domain.user.dto.UserUpdateReq;
+import yuquiz.domain.user.entity.User;
+import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
 
 @Service
@@ -21,4 +27,42 @@ public class UserService {
         String encodePassword = passwordEncoder.encode(signUpReq.password());
         userRepository.save(signUpReq.toEntity(encodePassword));
     }
+
+    /* 사용자 정보 불러오기 */
+    @Transactional(readOnly = true)
+    public UserDetailsRes getUserInfo(Long userId) {
+
+        return UserDetailsRes.fromEntity(findUserByUserId(userId));
+    }
+
+    /* 사용자 정보 업데이트 */
+    @Transactional
+    public void updateUserInfo(UserUpdateReq updateReq, Long userId) {
+
+        User foundUser = findUserByUserId(userId);
+
+        String encodePassword = passwordEncoder.encode(updateReq.password());
+
+        foundUser.updateUser(encodePassword, updateReq.nickname(),
+                updateReq.email(), updateReq.agreeEmail(), updateReq.majorName());
+    }
+
+    /* 사용자 정보 삭제 */
+    @Transactional
+    public void deleteUserInfo(Long userId) {
+
+        try {
+            userRepository.deleteById(userId);
+        } catch (EmptyResultDataAccessException e) {
+            throw new CustomException(UserExceptionCode.INVALID_USERID);
+        }
+    }
+
+    /* 사용자 불러오기 */
+    private User findUserByUserId(Long userId) {
+
+        return userRepository.findById(userId).orElseThrow(() ->
+                new CustomException(UserExceptionCode.INVALID_USERID));
+    }
+
 }

--- a/src/main/java/yuquiz/domain/user/service/UserService.java
+++ b/src/main/java/yuquiz/domain/user/service/UserService.java
@@ -1,7 +1,6 @@
 package yuquiz.domain.user.service;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -51,11 +50,7 @@ public class UserService {
     @Transactional
     public void deleteUserInfo(Long userId) {
 
-        try {
-            userRepository.deleteById(userId);
-        } catch (EmptyResultDataAccessException e) {
-            throw new CustomException(UserExceptionCode.INVALID_USERID);
-        }
+        userRepository.deleteById(userId);
     }
 
     /* 사용자 불러오기 */

--- a/src/test/java/yuquiz/user/controller/SecuredUserControllerTest.java
+++ b/src/test/java/yuquiz/user/controller/SecuredUserControllerTest.java
@@ -1,0 +1,212 @@
+package yuquiz.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import yuquiz.common.exception.CustomException;
+import yuquiz.domain.user.controller.UserController;
+import yuquiz.domain.user.dto.UserDetailsRes;
+import yuquiz.domain.user.dto.UserUpdateReq;
+import yuquiz.domain.user.entity.Role;
+import yuquiz.domain.user.entity.User;
+import yuquiz.domain.user.exception.UserExceptionCode;
+import yuquiz.domain.user.service.UserService;
+import yuquiz.security.auth.SecurityUserDetails;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+public class SecuredUserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    private SecurityUserDetails userDetails;
+    private User user;
+
+    @BeforeEach
+    void setUp(WebApplicationContext webApplicationContext) {
+        this.mockMvc = MockMvcBuilders
+                .webAppContextSetup(webApplicationContext)
+                .apply(springSecurity())
+                .defaultRequest(get("/**").with(csrf()))
+                .defaultRequest(put("/**").with(csrf()))
+                .defaultRequest(delete("/**").with(csrf()))
+                .build();
+
+        this.user = User.builder()
+                .username("test")
+                .password("password")
+                .nickname("테스터")
+                .email("test@gmail.com")
+                .role(Role.USER)
+                .build();
+
+        this.userDetails = new SecurityUserDetails(user);
+    }
+
+    @Test
+    @DisplayName("사용자 정보 불러오기 테스트")
+    void getUserInfoTest() throws Exception {
+        // given
+        UserDetailsRes userDetailsRes =
+                new UserDetailsRes("test", "테스터", "test@gmail.com", true, "컴퓨터공학과");
+
+        given(userService.getUserInfo(userDetails.getId())).willReturn(userDetailsRes);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                get("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(userDetailsRes.username()))
+                .andExpect(jsonPath("$.nickname").value(userDetailsRes.nickname()))
+                .andExpect(jsonPath("$.email").value(userDetailsRes.email()));
+    }
+
+    @Test
+    @DisplayName("회원 정보 업데이트 테스트")
+    void updateUserInfoTest() throws Exception {
+        // given
+        UserUpdateReq updateReq =
+                new UserUpdateReq("newPassword1234", "테스터1", "new@gmail.com", "컴공", false);
+
+        doNothing().when(userService).updateUserInfo(any(UserUpdateReq.class), eq(userDetails.getId()));
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(updateReq))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response").value("회원 정보 수정 성공."));
+    }
+
+    @Test
+    @DisplayName("회원 업데이트 실패 테스트 - 정보 누락")
+    void updateUserInfoFailedTest() throws Exception {
+        // given
+        UserUpdateReq updateReq =
+                new UserUpdateReq(null, null, null, null, false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(updateReq))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.password").value("비밀번호는 필수 입력 값입니다."))
+                .andExpect(jsonPath("$.nickname").value("닉네임은 필수 입력 값입니다."))
+                .andExpect(jsonPath("$.email").value("이메일은 필수 입력 값입니다."))
+                .andExpect(jsonPath("$.majorName").value("학과는 필수 선택 값입니다."));
+    }
+
+    @Test
+    @DisplayName("회원 업데이트 실패 테스트 - 정보 누락")
+    void updateUserInfoInsufficientTest() throws Exception {
+        // given
+        UserUpdateReq updateReq =
+                new UserUpdateReq("new", "x", "newgmail.com", "컴공", false);
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                put("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsBytes(updateReq))
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.password").value("비밀번호는 8~16자 영문과 숫자를 사용하세요."))
+                .andExpect(jsonPath("$.nickname").value("닉네임은 특수문자를 제외한 2~10자리여야 합니다."))
+                .andExpect(jsonPath("$.email").value("유효한 이메일 형식이 아닙니다."));
+    }
+
+    @Test
+    @DisplayName("회원 정보 삭제 테스트")
+    void deleteUserInfoTest() throws Exception {
+        // given
+        doNothing().when(userService).deleteUserInfo(userDetails.getId());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("회원 정보 삭제 실패 테스트 - 사용자 존재하지 않음")
+    void deleteUserInfoFailedByUserNotFoundTest() throws Exception {
+        // given
+        doThrow(new CustomException(UserExceptionCode.INVALID_USERID)).when(userService).deleteUserInfo(userDetails.getId());
+
+        // when
+        ResultActions resultActions = mockMvc.perform(
+                delete("/api/v1/users/my")
+                        .with(user(userDetails))
+                        .contentType(MediaType.APPLICATION_JSON)
+        );
+
+        // then
+        resultActions
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value(UserExceptionCode.INVALID_USERID.getMessage()));
+    }
+}

--- a/src/test/java/yuquiz/user/service/UserServiceTest.java
+++ b/src/test/java/yuquiz/user/service/UserServiceTest.java
@@ -43,7 +43,7 @@ public class UserServiceTest {
     private Long userId;
 
     @BeforeEach
-    void SetUp() {
+    void setUp() {
         this.user = User.builder()
                 .username("test")
                 .password("password123")
@@ -85,9 +85,9 @@ public class UserServiceTest {
         // then
         verify(userRepository, times(1)).findById(userId);
         assertNotNull(userDetailsRes);
-        assertEquals(userDetailsRes.username(), user.getUsername());
-        assertEquals(userDetailsRes.email(), user.getEmail());
-        assertEquals(userDetailsRes.nickname(), user.getNickname());
+        assertEquals(user.getUsername(), userDetailsRes.username());
+        assertEquals(user.getEmail(), userDetailsRes.email());
+        assertEquals(user.getNickname(), userDetailsRes.nickname());
     }
 
     @Test

--- a/src/test/java/yuquiz/user/service/UserServiceTest.java
+++ b/src/test/java/yuquiz/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package yuquiz.user.service;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -7,11 +8,20 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import yuquiz.common.exception.CustomException;
 import yuquiz.domain.user.dto.SignUpReq;
+import yuquiz.domain.user.dto.UserDetailsRes;
+import yuquiz.domain.user.dto.UserUpdateReq;
 import yuquiz.domain.user.entity.User;
+import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
 import yuquiz.domain.user.service.UserService;
 
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
@@ -29,6 +39,22 @@ public class UserServiceTest {
     @InjectMocks
     private UserService userService;
 
+    private User user;
+    private Long userId;
+
+    @BeforeEach
+    void SetUp() {
+        this.user = User.builder()
+                .username("test")
+                .password("password123")
+                .email("test@gmail.com")
+                .nickname("테스터")
+                .agreeEmail(true)
+                .majorName("컴퓨터공학과")
+                .build();
+        this.userId = 1L;
+    }
+
     @Test
     @DisplayName("회원가입 테스트")
     void signUpTest() {
@@ -45,5 +71,70 @@ public class UserServiceTest {
 
         // then
         verify(userRepository, times(1)).save(any(User.class));
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 테스트")
+    void getUserInfoTest() {
+        // given
+        given(userRepository.findById(userId)).willReturn(Optional.ofNullable(user));
+
+        // when
+        UserDetailsRes userDetailsRes = userService.getUserInfo(userId);
+
+        // then
+        verify(userRepository, times(1)).findById(userId);
+        assertNotNull(userDetailsRes);
+        assertEquals(userDetailsRes.username(), user.getUsername());
+        assertEquals(userDetailsRes.email(), user.getEmail());
+        assertEquals(userDetailsRes.nickname(), user.getNickname());
+    }
+
+    @Test
+    @DisplayName("회원 정보 업데이트 테스트")
+    void updateUserInfoTest() {
+        // given
+        UserUpdateReq updateReq =
+                new UserUpdateReq("newPassword1234", "테스터1", "new@gmail.com", "컴공", false);
+
+        given(userRepository.findById(userId)).willReturn(Optional.ofNullable(user));
+
+        // when
+        userService.updateUserInfo(updateReq, userId);
+
+        // then
+        verify(userRepository, times(1)).findById(userId);
+        assertEquals(user.getNickname(), updateReq.nickname());
+        assertEquals(user.getEmail(), updateReq.email());
+        assertEquals(user.getMajorName(), updateReq.majorName());
+        assertEquals(user.isAgreeEmail(), updateReq.agreeEmail());
+    }
+
+    @Test
+    @DisplayName("회원 정보 탈퇴 테스트")
+    void deleteUserInfoTest() {
+        // given
+
+        // when
+        userService.deleteUserInfo(userId);
+
+        // then
+        verify(userRepository, times(1)).deleteById(userId);
+    }
+
+    @Test
+    @DisplayName("회원 정보 조회 실패 테스트 - 사용자 정보 없음")
+    void getUserFailedByUserNotFoundTest() {
+        // given
+        given(userRepository.findById(userId)).willThrow(new CustomException(UserExceptionCode.INVALID_USERID));
+
+        // when
+        CustomException exception = assertThrows(CustomException.class, () -> {
+            userService.getUserInfo(userId);
+        });
+
+        // then
+        assertEquals(UserExceptionCode.INVALID_USERID, exception.getExceptionCode());
+        verify(userRepository, times(1)).findById(userId);
     }
 }


### PR DESCRIPTION
## 개요
사용자 정보 조회, 업데이트 및 삭제 구현

## 구현 사항
 - 사용자 정보 조회, 업데이트 및 삭제 구현
 - 관련 test 코드 작성
 - 스웨거 연동

## 기타
사용자 정보를 업데이트 할 때, 비밀번호 같은 경우에는 변경하고 싶지 않을 수 있습니다.
그렇기 때문에, 비밀번호 변경 페이지를 따로 만드는건 어떻게 생각하시나요? (모달창과 같은 것을 띄어서 변경한다던지..)
그렇게 하면 현재의 코드에서 사용자 정보 업데이트 중 password는 따로 빼서 만들고, api요청을 새로 만들 생각입니다.

또한, 닉네임, 아이디 등 중복성 검사는 추후에 추가 예정입니다. (api도 추가예정)

## 테스트 화면

작성한 테스트 코드에 예외상황 테스트까지 다 완료하였습니다.

1. 회원 정보 불러오기
![image](https://github.com/user-attachments/assets/e3933d36-38b7-4ce0-aec2-753655a21e1d)

2. 회원 정보 수정하기
![image](https://github.com/user-attachments/assets/9628da25-4e45-413f-97af-e5ef52b90db4)

3. 회원 정보 삭제하기
![image](https://github.com/user-attachments/assets/e5540225-70e4-44a8-971f-2f5bdc971fd7)

