### PR TITLE
feat: 관리자용 게시글, 퀴즈, 신고, 사용자 Swagger 작성 및 삭제 예외처리 변경

### DIFF
--- a/src/main/java/yuquiz/domain/post/api/AdminPostApi.java
+++ b/src/main/java/yuquiz/domain/post/api/AdminPostApi.java
@@ -1,0 +1,67 @@
+package yuquiz.domain.post.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[관리자용 게시글 API]", description = "관리자용 게시글 관련 API")
+public interface AdminPostApi {
+
+    @Operation(summary = "전체 게시글 페이지별 최신순 조회", description = "전체 게시글을 페이지별로 조회하는 API입니다. 게시글은 최신순으로 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "게시글 조회 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "totalPages": 1,
+                            "totalElements": 1,
+                            "first": true,
+                            "last": true,
+                            "size": 10,
+                            "content": [
+                                {
+                                    "postId": 2,
+                                    "postTitle": "게시글 제목",
+                                    "nickname": "테스터",
+                                    "createdAt": "2024-08-12T01:10:10"
+                                }
+                            ],
+                            "number": 0,
+                            "sort": {
+                                "empty": true,
+                                "unsorted": true,
+                                "sorted": false
+                            },
+                            "pageable": {
+                                "pageNumber": 0,
+                                "pageSize": 10,
+                                "sort": {
+                                    "empty": true,
+                                    "unsorted": true,
+                                    "sorted": false
+                                },
+                                "offset": 0,
+                                "unpaged": false,
+                                "paged": true
+                            },
+                            "numberOfElements": 1,
+                            "empty": false
+                        }
+                    """)
+            }))
+    })
+    ResponseEntity<?> getLatestPostsByPage(@RequestParam @Min(0) Integer page);
+
+    @Operation(summary = "특정 게시글 삭제", description = "게시글id를 기반으로 게시글을 삭제하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
+    })
+    ResponseEntity<?> deletePost(@PathVariable("postId") Long postId);
+}

--- a/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
+++ b/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import yuquiz.domain.post.api.AdminPostApi;
 import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.service.AdminPostService;
 
 @RestController
 @RequestMapping("/api/v1/admin/posts")
 @RequiredArgsConstructor
-public class AdminPostController {
+public class AdminPostController implements AdminPostApi {
 
     private final AdminPostService adminPostService;
 

--- a/src/main/java/yuquiz/domain/post/service/AdminPostService.java
+++ b/src/main/java/yuquiz/domain/post/service/AdminPostService.java
@@ -32,10 +32,6 @@ public class AdminPostService {
     @Transactional
     public void deletePost(Long postId) {
 
-        try{
-            postRepository.deleteById(postId);
-        } catch (EmptyResultDataAccessException e) {
-            throw new CustomException(PostExceptionCode.INVALID_ID);
-        }
+        postRepository.deleteById(postId);
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/api/AdminQuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/AdminQuizApi.java
@@ -1,0 +1,78 @@
+package yuquiz.domain.quiz.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+
+@Tag(name = "[관리자용 퀴즈 API]", description = "관리자용 퀴즈 관련 API")
+public interface AdminQuizApi {
+
+    @Operation(summary = "전체 퀴즈 페이지별 최신순 조회", description = "전체 퀴즈를 페이지별로 조회하는 API입니다. 퀴즈는 최신순으로 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "totalPages": 1,
+                            "totalElements": 2,
+                            "first": true,
+                            "last": true,
+                            "size": 10,
+                            "content": [
+                                {
+                                    "quizId": 7,
+                                    "quizTitle": "testing",
+                                    "nickname": "테스터111",
+                                    "createdAt": "2024-08-11T19:43:53",
+                                    "likeCount": 5,
+                                    "viewCount": 15
+                                },
+                                {
+                                    "quizId": 4,
+                                    "quizTitle": "보지마세요",
+                                    "nickname": "테스터다",
+                                    "createdAt": "2024-08-10T16:33:00",
+                                    "likeCount": 0,
+                                    "viewCount": 1
+                                }
+                            ],
+                            "number": 0,
+                            "sort": {
+                                "empty": true,
+                                "sorted": false,
+                                "unsorted": true
+                            },
+                            "numberOfElements": 2,
+                            "pageable": {
+                                "pageNumber": 0,
+                                "pageSize": 10,
+                                "sort": {
+                                    "empty": true,
+                                    "sorted": false,
+                                    "unsorted": true
+                                },
+                                "offset": 0,
+                                "paged": true,
+                                "unpaged": false
+                            },
+                            "empty": false
+                        }
+                    """)
+            }))
+    })
+    ResponseEntity<?> getQuizPage(@RequestParam @Min(0) Integer page);
+
+    @Operation(summary = "특정 퀴즈 삭제", description = "퀴즈id를 기반으로 퀴즈를 삭제하는 API입니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "퀴즈 삭제 성공")
+    })
+    ResponseEntity<?> deleteQuiz(@PathVariable("quizId") Long quizId);
+}

--- a/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import yuquiz.domain.quiz.api.AdminQuizApi;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.service.AdminQuizService;
 
 @RestController
 @RequestMapping("/api/v1/admin/quizzes")
 @RequiredArgsConstructor
-public class AdminQuizController {
+public class AdminQuizController implements AdminQuizApi {
 
     private final AdminQuizService adminQuizService;
 

--- a/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
@@ -32,10 +32,6 @@ public class AdminQuizService {
     @Transactional
     public void deleteQuiz(Long quizId){
 
-        try{
-           quizRepository.deleteById(quizId);
-        } catch (EmptyResultDataAccessException e) {
-           throw new CustomException(QuizExceptionCode.INVALID_ID);
-        }
+        quizRepository.deleteById(quizId);
     }
 }

--- a/src/main/java/yuquiz/domain/report/api/AdminReportApi.java
+++ b/src/main/java/yuquiz/domain/report/api/AdminReportApi.java
@@ -1,0 +1,56 @@
+package yuquiz.domain.report.api;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+
+@Tag(name = "[관리자용 신고 API]", description = "관리자용 신고 관련 API")
+public interface AdminReportApi {
+
+	@Operation(summary = "전체 신고 페이지별 최신순 조회", description = "전체 신고를 페이지별로 조회하는 API입니다. 신고는 최신순으로 조회됩니다.")
+	@ApiResponses({
+		@ApiResponse(responseCode = "200", description = "신고 조회 성공",
+			content = @Content(mediaType = "application/json", examples = {
+				@ExampleObject(value = """
+					{
+						"totalPages": 0,
+						"totalElements": 0,
+						"first": true,
+						"last": true,
+						"size": 10,
+						"content": [],
+						"number": 0,
+						"sort": {
+							"empty": true,
+							"unsorted": true,
+							"sorted": false
+						},
+						"pageable": {
+							"pageNumber": 0,
+							"pageSize": 10,
+							"sort": {
+								"empty": true,
+								"unsorted": true,
+								"sorted": false
+							},
+							"offset": 0,
+							"unpaged": false,
+							"paged": true
+						},
+						"numberOfElements": 0,
+						"empty": true
+					}
+					""")
+			}))
+	})
+	ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer page);
+
+
+}

--- a/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
+++ b/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
@@ -1,11 +1,15 @@
 package yuquiz.domain.report.controller;
 
-import jakarta.validation.constraints.Min;
-import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
 import yuquiz.domain.report.dto.ReportSummaryRes;
 import yuquiz.domain.report.service.AdminReportService;
 
@@ -17,10 +21,10 @@ public class AdminReportController {
     private final AdminReportService adminReportService;
 
     @GetMapping
-    public ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer pageNumber) {
+    public ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer page) {
 
-        Page<ReportSummaryRes> page = adminReportService.getReportPage(pageNumber);
+        Page<ReportSummaryRes> reports = adminReportService.getReportPage(page);
 
-        return ResponseEntity.status(HttpStatus.OK).body(page);
+        return ResponseEntity.status(HttpStatus.OK).body(reports);
     }
 }

--- a/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
+++ b/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
@@ -10,16 +10,18 @@ import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import yuquiz.domain.report.api.AdminReportApi;
 import yuquiz.domain.report.dto.ReportSummaryRes;
 import yuquiz.domain.report.service.AdminReportService;
 
 @RestController
 @RequestMapping("/api/v1/admin/report")
 @RequiredArgsConstructor
-public class AdminReportController {
+public class AdminReportController implements AdminReportApi {
 
     private final AdminReportService adminReportService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer page) {
 

--- a/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
@@ -1,0 +1,75 @@
+package yuquiz.domain.user.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "[관리자용 사용자 API]", description = "관리자용 사용자 관련 API")
+public interface AdminUserApi {
+
+    @Operation(summary = "전체 사용자 페이지별 최신순 조회", description = "전체 사용자를 페이지별로 조회하는 API입니다. 사용자는 최신순으로 조회됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "totalPages": 1,
+                            "totalElements": 3,
+                            "first": true,
+                            "last": true,
+                            "size": 10,
+                            "content": [
+                                {
+                                    "id": 8,
+                                    "username": "admin",
+                                    "nickname": "admin",
+                                    "email": "admin@gmail.com",
+                                    "createdAt": "2024-08-10T18:03:12.727292"
+                                },
+                                {
+                                    "id": 7,
+                                    "username": "test111",
+                                    "nickname": "테스터111",
+                                    "email": "test111@gmail.com",
+                                    "createdAt": "2024-08-10T02:13:51.658051"
+                                },
+                                {
+                                    "id": 1,
+                                    "username": "test",
+                                    "nickname": "테스터",
+                                    "email": "test@gmail.com",
+                                    "createdAt": "2024-08-05T03:25:02.974794"
+                                }
+                            ],
+                            "number": 0,
+                            "sort": {
+                                "empty": true,
+                                "unsorted": true,
+                                "sorted": false
+                            },
+                            "pageable": {
+                                "pageNumber": 0,
+                                "pageSize": 10,
+                                "sort": {
+                                    "empty": true,
+                                    "unsorted": true,
+                                    "sorted": false
+                                },
+                                "offset": 0,
+                                "unpaged": false,
+                                "paged": true
+                            },
+                            "numberOfElements": 3,
+                            "empty": false
+                        }
+                    """)
+            }))
+    })
+    ResponseEntity<?> getUserPage(@RequestParam @Min(0) Integer page);
+}

--- a/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
@@ -6,13 +6,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import yuquiz.domain.user.api.AdminUserApi;
 import yuquiz.domain.user.dto.UserSummaryRes;
 import yuquiz.domain.user.service.AdminUserService;
 
 @RestController
 @RequestMapping("/api/v1/admin/users")
 @RequiredArgsConstructor
-public class AdminUserController {
+public class AdminUserController implements AdminUserApi {
 
     private final AdminUserService adminUserService;
 


### PR DESCRIPTION
## 개요
관리자용 게시글, 퀴즈, 신고, 사용자 관련 Swagger 작성

게시글과 퀴즈를 삭제하는 서비스에서 예외처리를 변경

## 구현 사항
관리자용 게시글, 퀴즈, 신고, 사용자 관련 Swagger를 작성했습니다.

기존에는 게시글이나 퀴즈를 delete할 때 없는 엔티티인 경우, 404 상태코드와 함께 없는 엔티티라는 메세지를 보내도록 설계되어 있었습니다.   
EmptyResultDataAccessException이 터지면 404를 보내주던 방식이었습니다.

하지만 Spring Data Jpa를 확인한 결과, 삭제 쿼리의 경우 없는 엔티티더라도 삭제성공으로 처리하는 것을 알게 되었습니다.
즉, EmptyResultDataAccessException는 터지지 않고 204(No Content)만을 반환하게 됩니다.

따라서, 예외를 처리해주는 로직을 없애고 단순히 delete문으로 대체하였습니다.