### PR TITLE
feat: 관리자용 조회시 정렬 후 조회 기능 추가

### DIFF
--- a/src/main/java/yuquiz/domain/post/api/AdminPostApi.java
+++ b/src/main/java/yuquiz/domain/post/api/AdminPostApi.java
@@ -10,11 +10,12 @@ import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.post.dto.PostSortType;
 
 @Tag(name = "[관리자용 게시글 API]", description = "관리자용 게시글 관련 API")
 public interface AdminPostApi {
 
-    @Operation(summary = "전체 게시글 페이지별 최신순 조회", description = "전체 게시글을 페이지별로 조회하는 API입니다. 게시글은 최신순으로 조회됩니다.")
+    @Operation(summary = "전체 게시글 페이지별 조회", description = "전체 게시글을 정렬 기준에 따라 페이지별로 조회하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "게시글 조회 성공",
                 content = @Content(mediaType = "application/json", examples = {
@@ -24,7 +25,7 @@ public interface AdminPostApi {
                             "totalElements": 1,
                             "first": true,
                             "last": true,
-                            "size": 10,
+                            "size": 20,
                             "content": [
                                 {
                                     "postId": 2,
@@ -35,17 +36,17 @@ public interface AdminPostApi {
                             ],
                             "number": 0,
                             "sort": {
-                                "empty": true,
-                                "unsorted": true,
-                                "sorted": false
+                                "empty": false,
+                                "unsorted": false,
+                                "sorted": true
                             },
                             "pageable": {
                                 "pageNumber": 0,
-                                "pageSize": 10,
+                                "pageSize": 20,
                                 "sort": {
-                                    "empty": true,
-                                    "unsorted": true,
-                                    "sorted": false
+                                    "empty": false,
+                                    "unsorted": false,
+                                    "sorted": true
                                 },
                                 "offset": 0,
                                 "unpaged": false,
@@ -57,9 +58,10 @@ public interface AdminPostApi {
                     """)
             }))
     })
-    ResponseEntity<?> getLatestPostsByPage(@RequestParam @Min(0) Integer page);
+    ResponseEntity<?> getAllPosts(@RequestParam PostSortType sort,
+                                  @RequestParam @Min(0) Integer page);
 
-    @Operation(summary = "특정 게시글 삭제", description = "게시글id를 기반으로 게시글을 삭제하는 API입니다.")
+    @Operation(summary = "특정 게시글 삭제", description = "게시글id를 기반으로 게시글을 삭제하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
     })

--- a/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
+++ b/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.domain.post.api.AdminPostApi;
+import yuquiz.domain.post.dto.PostSortType;
 import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.service.AdminPostService;
 
@@ -18,9 +19,10 @@ public class AdminPostController implements AdminPostApi {
     private final AdminPostService adminPostService;
 
     @GetMapping
-    public ResponseEntity<?> getLatestPostsByPage(@RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllPosts(@RequestParam PostSortType sort,
+                                                  @RequestParam @Min(0) Integer page) {
 
-        Page<PostSummaryRes> posts = adminPostService.getLatestPostsByPage(page);
+        Page<PostSummaryRes> posts = adminPostService.getAllPosts(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(posts);
     }

--- a/src/main/java/yuquiz/domain/post/dto/PostSortType.java
+++ b/src/main/java/yuquiz/domain/post/dto/PostSortType.java
@@ -1,19 +1,17 @@
-package yuquiz.domain.quiz.dto;
+package yuquiz.domain.post.dto;
 
 import org.springframework.data.domain.Sort;
 
-public enum SortType {
-    LIKE_DESC("likeCount", Sort.Direction.DESC),
-    LIKE_ASC("likeCount", Sort.Direction.ASC),
-    VIEW_DESC("viewCount", Sort.Direction.DESC),
-    VIEW_ASC("viewCount", Sort.Direction.ASC),
+public enum PostSortType {
+    TITL_DESC("title", Sort.Direction.DESC),
+    TITL_ASC("title", Sort.Direction.ASC),
     DATE_DESC("createdAt", Sort.Direction.DESC),
     DATE_ASC("createdAt", Sort.Direction.ASC);
 
     private String type;
     private Sort.Direction direction;
 
-    SortType(String type, Sort.Direction direction) {
+    PostSortType(String type, Sort.Direction direction) {
         this.type = type;
         this.direction = direction;
     }

--- a/src/main/java/yuquiz/domain/post/service/AdminPostService.java
+++ b/src/main/java/yuquiz/domain/post/service/AdminPostService.java
@@ -2,15 +2,13 @@ package yuquiz.domain.post.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import yuquiz.common.exception.CustomException;
+import yuquiz.domain.post.dto.PostSortType;
 import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.entity.Post;
-import yuquiz.domain.post.exception.PostExceptionCode;
 import yuquiz.domain.post.repository.PostRepository;
 
 @Service
@@ -19,12 +17,12 @@ public class AdminPostService {
 
     private final PostRepository postRepository;
 
-    private static final Integer POST_PER_PAGE = 10;
+    private static final Integer POST_PER_PAGE = 20;
 
-    public Page<PostSummaryRes> getLatestPostsByPage(Integer page) {
+    public Page<PostSummaryRes> getAllPosts(PostSortType sort, Integer page) {
 
-        Pageable pageable = PageRequest.of(page, POST_PER_PAGE);
-        Page<Post> posts = postRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Pageable pageable = PageRequest.of(page, POST_PER_PAGE, sort.getSort());
+        Page<Post> posts = postRepository.findAll(pageable);
 
         return posts.map(PostSummaryRes::fromEntity);
     }

--- a/src/main/java/yuquiz/domain/quiz/api/AdminQuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/AdminQuizApi.java
@@ -1,9 +1,5 @@
 package yuquiz.domain.quiz.api;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -11,21 +7,25 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.quiz.dto.QuizSortType;
 
 @Tag(name = "[관리자용 퀴즈 API]", description = "관리자용 퀴즈 관련 API")
 public interface AdminQuizApi {
 
-    @Operation(summary = "전체 퀴즈 페이지별 최신순 조회", description = "전체 퀴즈를 페이지별로 조회하는 API입니다. 퀴즈는 최신순으로 조회됩니다.")
+    @Operation(summary = "전체 퀴즈 페이지별 조회", description = "전체 퀴즈를 정렬 기준에 따라 페이지별로 조회하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공",
                 content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(value = """
                         {
                             "totalPages": 1,
-                            "totalElements": 2,
+                            "totalElements": 3,
                             "first": true,
                             "last": true,
-                            "size": 10,
+                            "size": 20,
                             "content": [
                                 {
                                     "quizId": 7,
@@ -36,41 +36,50 @@ public interface AdminQuizApi {
                                     "viewCount": 15
                                 },
                                 {
-                                    "quizId": 4,
-                                    "quizTitle": "보지마세요",
-                                    "nickname": "테스터다",
-                                    "createdAt": "2024-08-10T16:33:00",
-                                    "likeCount": 0,
-                                    "viewCount": 1
+                                    "quizId": 8,
+                                    "quizTitle": "hello",
+                                    "nickname": "테스터",
+                                    "createdAt": "2024-08-12T13:32:55",
+                                    "likeCount": 2,
+                                    "viewCount": 20
+                                },
+                                {
+                                    "quizId": 9,
+                                    "quizTitle": "testtest",
+                                    "nickname": "admin",
+                                    "createdAt": "2024-08-12T13:33:45",
+                                    "likeCount": 10,
+                                    "viewCount": 222
                                 }
                             ],
                             "number": 0,
                             "sort": {
-                                "empty": true,
-                                "sorted": false,
-                                "unsorted": true
+                                "empty": false,
+                                "unsorted": false,
+                                "sorted": true
                             },
-                            "numberOfElements": 2,
                             "pageable": {
                                 "pageNumber": 0,
-                                "pageSize": 10,
+                                "pageSize": 20,
                                 "sort": {
-                                    "empty": true,
-                                    "sorted": false,
-                                    "unsorted": true
+                                    "empty": false,
+                                    "unsorted": false,
+                                    "sorted": true
                                 },
                                 "offset": 0,
-                                "paged": true,
-                                "unpaged": false
+                                "unpaged": false,
+                                "paged": true
                             },
+                            "numberOfElements": 3,
                             "empty": false
                         }
                     """)
             }))
     })
-    ResponseEntity<?> getQuizPage(@RequestParam @Min(0) Integer page);
+    ResponseEntity<?> getAllQuizzes(@RequestParam QuizSortType sort,
+                                    @RequestParam @Min(0) Integer page);
 
-    @Operation(summary = "특정 퀴즈 삭제", description = "퀴즈id를 기반으로 퀴즈를 삭제하는 API입니다.")
+    @Operation(summary = "특정 퀴즈 삭제", description = "퀴즈id를 기반으로 퀴즈를 삭제하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "퀴즈 삭제 성공")
     })

--- a/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import yuquiz.domain.quiz.dto.AnswerReq;
 import yuquiz.domain.quiz.dto.QuizReq;
-import yuquiz.domain.quiz.dto.SortType;
+import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.security.auth.SecurityUserDetails;
 
 @Tag(name = "[퀴즈 API]", description = "퀴즈 관련 API")
@@ -243,5 +243,5 @@ public interface QuizApi {
     })
     ResponseEntity<?> getQuizzesBySubject(@PathVariable(value = "subjectId") Long subjectId,
                                                  @RequestParam(value = "page") @Min(0) Integer page,
-                                                 @RequestParam(value = "sort") SortType sort);
+                                                 @RequestParam(value = "sort") QuizSortType sort);
 }

--- a/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
@@ -243,7 +243,7 @@ public interface QuizApi {
     })
     ResponseEntity<?> getQuizzesBySubject(@PathVariable(value = "subjectId") Long subjectId,
                                           @RequestParam(value = "page") @Min(0) Integer page,
-                                          @RequestParam(value = "sort") SortType sort);
+                                          @RequestParam(value = "sort") QuizSortType sort);
 
     @Operation(summary = "퀴즈 검색", description = "키워드를 이용해 퀴즈를 검색하는 기능")
     @ApiResponses({
@@ -343,6 +343,6 @@ public interface QuizApi {
                     })),
     })
     ResponseEntity<?> getQuizzesByKeyword(@RequestParam(value = "keyword") String keyword,
-                                          @RequestParam(value = "sort") SortType sort,
+                                          @RequestParam(value = "sort") QuizSortType sort,
                                           @RequestParam(value = "page") @Min(0) Integer page);
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.domain.quiz.api.AdminQuizApi;
+import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.service.AdminQuizService;
 
@@ -18,9 +19,10 @@ public class AdminQuizController implements AdminQuizApi {
     private final AdminQuizService adminQuizService;
 
     @GetMapping
-    public ResponseEntity<?> getQuizPage(@RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllQuizzes(@RequestParam QuizSortType sort,
+                                           @RequestParam @Min(0) Integer page) {
 
-        Page<QuizSummaryRes> quizzes = adminQuizService.getQuizPage(page);
+        Page<QuizSummaryRes> quizzes = adminQuizService.getAllQuizzes(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -74,7 +74,7 @@ public class QuizController implements QuizApi {
 
     @GetMapping
     public ResponseEntity<?> getQuizzesByKeyword(@RequestParam(value = "keyword") String keyword,
-                                                 @RequestParam(value = "sort") SortType sort,
+                                                 @RequestParam(value = "sort") QuizSortType sort,
                                                  @RequestParam(value = "page") @Min(0) Integer page) {
         Page<QuizSummaryRes> quizzes = quizService.getQuizzesByKeyword(keyword, sort, page);
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -10,7 +10,10 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.quiz.api.QuizApi;
-import yuquiz.domain.quiz.dto.*;
+import yuquiz.domain.quiz.dto.AnswerReq;
+import yuquiz.domain.quiz.dto.QuizReq;
+import yuquiz.domain.quiz.dto.QuizSortType;
+import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.service.QuizService;
 import yuquiz.security.auth.SecurityUserDetails;
 
@@ -62,7 +65,7 @@ public class QuizController implements QuizApi {
     @GetMapping("/subject/{subjectId}")
     public ResponseEntity<?> getQuizzesBySubject(@PathVariable(value = "subjectId") Long subjectId,
                                                  @RequestParam(value = "page") @Min(0) Integer page,
-                                                 @RequestParam(value = "sort") SortType sort) {
+                                                 @RequestParam(value = "sort") QuizSortType sort) {
         Page<QuizSummaryRes> quizzes = quizService.getQuizzesBySubject(subjectId, sort, page);
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }

--- a/src/main/java/yuquiz/domain/quiz/dto/QuizSortType.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizSortType.java
@@ -1,0 +1,24 @@
+package yuquiz.domain.quiz.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum QuizSortType {
+    LIKE_DESC("likeCount", Sort.Direction.DESC),
+    LIKE_ASC("likeCount", Sort.Direction.ASC),
+    VIEW_DESC("viewCount", Sort.Direction.DESC),
+    VIEW_ASC("viewCount", Sort.Direction.ASC),
+    DATE_DESC("createdAt", Sort.Direction.DESC),
+    DATE_ASC("createdAt", Sort.Direction.ASC);
+
+    private String type;
+    private Sort.Direction direction;
+
+    QuizSortType(String type, Sort.Direction direction) {
+        this.type = type;
+        this.direction = direction;
+    }
+
+    public Sort getSort() {
+        return Sort.by(direction, type);
+    }
+}

--- a/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
@@ -2,15 +2,13 @@ package yuquiz.domain.quiz.service;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import yuquiz.common.exception.CustomException;
+import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.entity.Quiz;
-import yuquiz.domain.quiz.exception.QuizExceptionCode;
 import yuquiz.domain.quiz.repository.QuizRepository;
 
 @Service
@@ -19,14 +17,14 @@ public class AdminQuizService {
 
     private final QuizRepository quizRepository;
 
-    private static final Integer QUIZ_PER_PAGE = 10;
+    private static final Integer QUIZ_PER_PAGE = 20;
 
-    public Page<QuizSummaryRes> getQuizPage(Integer pageNumber) {
+    public Page<QuizSummaryRes> getAllQuizzes(QuizSortType sort, Integer page) {
 
-        Pageable pageable = PageRequest.of(pageNumber, QUIZ_PER_PAGE);
-        Page<Quiz> page = quizRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Pageable pageable = PageRequest.of(page, QUIZ_PER_PAGE, sort.getSort());
+        Page<Quiz> quizzes = quizRepository.findAll(pageable);
 
-        return page.map(QuizSummaryRes::fromEntity);
+        return quizzes.map(QuizSummaryRes::fromEntity);
     }
 
     @Transactional

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -91,8 +91,8 @@ public class QuizService {
         return quizzes.map(QuizSummaryRes::fromEntity);
     }
 
-    public Page<QuizSummaryRes> getQuizzesByKeyword(String keyword, SortType sort, Integer page) {
-        Pageable pageable = PageRequest.of(page, POST_PER_PAGE, sort.getSort());
+    public Page<QuizSummaryRes> getQuizzesByKeyword(String keyword, QuizSortType sort, Integer page) {
+        Pageable pageable = PageRequest.of(page, QUIZ_PER_PAGE, sort.getSort());
 
         Page<Quiz> quizzes = quizRepository.findAllByTitleContainingOrQuestionContaining(keyword, keyword, pageable);
 

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -4,14 +4,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
 import yuquiz.domain.quiz.dto.QuizReq;
 import yuquiz.domain.quiz.dto.QuizRes;
+import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
-import yuquiz.domain.quiz.dto.SortType;
 import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quiz.exception.QuizExceptionCode;
 import yuquiz.domain.quiz.repository.QuizRepository;
@@ -30,7 +29,7 @@ public class QuizService {
     private final UserRepository userRepository;
     private final SubjectRepository subjectRepository;
 
-    private static final Integer POST_PER_PAGE = 20;
+    private static final Integer QUIZ_PER_PAGE = 20;
 
     @Transactional
     public void createQuiz(QuizReq quizReq, Long userId) {
@@ -77,11 +76,11 @@ public class QuizService {
         return findQuizByQuizId(quizId).getAnswer();
     }
 
-    public Page<QuizSummaryRes> getQuizzesBySubject(Long subjectId, SortType sort, Integer page) {
+    public Page<QuizSummaryRes> getQuizzesBySubject(Long subjectId, QuizSortType sort, Integer page) {
         Subject subject = subjectRepository.findById(subjectId)
                 .orElseThrow(() -> new CustomException(SubjectExceptionCode.INVALID_ID));
 
-        Pageable pageable = PageRequest.of(page, POST_PER_PAGE, sort.getSort());
+        Pageable pageable = PageRequest.of(page, QUIZ_PER_PAGE, sort.getSort());
         Page<Quiz> quizzes =  quizRepository.findAllBySubject(subject, pageable);
 
         return quizzes.map(QuizSummaryRes::fromEntity);

--- a/src/main/java/yuquiz/domain/report/api/AdminReportApi.java
+++ b/src/main/java/yuquiz/domain/report/api/AdminReportApi.java
@@ -1,8 +1,5 @@
 package yuquiz.domain.report.api;
 
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.RequestParam;
-
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -10,47 +7,64 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.report.dto.ReportSortType;
 
 @Tag(name = "[관리자용 신고 API]", description = "관리자용 신고 관련 API")
 public interface AdminReportApi {
 
-	@Operation(summary = "전체 신고 페이지별 최신순 조회", description = "전체 신고를 페이지별로 조회하는 API입니다. 신고는 최신순으로 조회됩니다.")
+	@Operation(summary = "전체 신고 페이지별 조회", description = "전체 신고를 정렬 기준에 따라 페이지별로 조회하는 API")
 	@ApiResponses({
 		@ApiResponse(responseCode = "200", description = "신고 조회 성공",
 			content = @Content(mediaType = "application/json", examples = {
 				@ExampleObject(value = """
-					{
-						"totalPages": 0,
-						"totalElements": 0,
-						"first": true,
-						"last": true,
-						"size": 10,
-						"content": [],
-						"number": 0,
-						"sort": {
-							"empty": true,
-							"unsorted": true,
-							"sorted": false
-						},
-						"pageable": {
-							"pageNumber": 0,
-							"pageSize": 10,
-							"sort": {
-								"empty": true,
-								"unsorted": true,
-								"sorted": false
-							},
-							"offset": 0,
-							"unpaged": false,
-							"paged": true
-						},
-						"numberOfElements": 0,
-						"empty": true
-					}
+						{
+							 "totalPages": 1,
+							 "totalElements": 2,
+							 "first": true,
+							 "last": true,
+							 "size": 20,
+							 "content": [
+								 {
+									 "reportId": 4,
+									 "quizId": 7,
+									 "reason": "재미없음",
+									 "type": "REPORT"
+								 },
+								 {
+									 "reportId": 5,
+									 "quizId": 7,
+									 "reason": "별로에요",
+									 "type": "REPORT"
+								 }
+							 ],
+							 "number": 0,
+							 "sort": {
+								 "empty": false,
+								 "unsorted": false,
+								 "sorted": true
+							 },
+							 "pageable": {
+								 "pageNumber": 0,
+								 "pageSize": 20,
+								 "sort": {
+									 "empty": false,
+									 "unsorted": false,
+									 "sorted": true
+								 },
+								 "offset": 0,
+								 "unpaged": false,
+								 "paged": true
+							 },
+							 "numberOfElements": 2,
+							 "empty": false
+					 	}
 					""")
 			}))
 	})
-	ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer page);
+	ResponseEntity<?> getAllReports(@RequestParam ReportSortType sort,
+									@RequestParam @Min(0) Integer page);
 
 
 }

--- a/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
+++ b/src/main/java/yuquiz/domain/report/controller/AdminReportController.java
@@ -1,5 +1,7 @@
 package yuquiz.domain.report.controller;
 
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -7,15 +9,13 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-
-import jakarta.validation.constraints.Min;
-import lombok.RequiredArgsConstructor;
 import yuquiz.domain.report.api.AdminReportApi;
+import yuquiz.domain.report.dto.ReportSortType;
 import yuquiz.domain.report.dto.ReportSummaryRes;
 import yuquiz.domain.report.service.AdminReportService;
 
 @RestController
-@RequestMapping("/api/v1/admin/report")
+@RequestMapping("/api/v1/admin/reports")
 @RequiredArgsConstructor
 public class AdminReportController implements AdminReportApi {
 
@@ -23,9 +23,10 @@ public class AdminReportController implements AdminReportApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getReportPage(@RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllReports(@RequestParam ReportSortType sort,
+                                           @RequestParam @Min(0) Integer page) {
 
-        Page<ReportSummaryRes> reports = adminReportService.getReportPage(page);
+        Page<ReportSummaryRes> reports = adminReportService.getAllReports(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(reports);
     }

--- a/src/main/java/yuquiz/domain/report/dto/ReportSortType.java
+++ b/src/main/java/yuquiz/domain/report/dto/ReportSortType.java
@@ -1,0 +1,22 @@
+package yuquiz.domain.report.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum ReportSortType {
+    TYPE_DESC("reportType", Sort.Direction.DESC),
+    TYPE_ASC("reportType", Sort.Direction.ASC),
+    DATE_DESC("createdAt", Sort.Direction.DESC),
+    DATE_ASC("createdAt", Sort.Direction.ASC);
+
+    private String type;
+    private Sort.Direction direction;
+
+    ReportSortType(String type, Sort.Direction direction) {
+        this.type = type;
+        this.direction = direction;
+    }
+
+    public Sort getSort() {
+        return Sort.by(direction, type);
+    }
+}

--- a/src/main/java/yuquiz/domain/report/service/AdminReportService.java
+++ b/src/main/java/yuquiz/domain/report/service/AdminReportService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import yuquiz.domain.report.dto.ReportSortType;
 import yuquiz.domain.report.dto.ReportSummaryRes;
 import yuquiz.domain.report.entity.Report;
 import yuquiz.domain.report.repository.ReportRepository;
@@ -15,13 +16,13 @@ public class AdminReportService {
 
     private final ReportRepository reportRepository;
 
-    private static final Integer REPORT_PER_PAGE = 10;
+    private static final Integer REPORT_PER_PAGE = 20;
 
-    public Page<ReportSummaryRes> getReportPage(Integer pageNumber) {
+    public Page<ReportSummaryRes> getAllReports(ReportSortType sort, Integer page) {
 
-        Pageable pageable = PageRequest.of(pageNumber, REPORT_PER_PAGE);
-        Page<Report> page = reportRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Pageable pageable = PageRequest.of(page, REPORT_PER_PAGE, sort.getSort());
+        Page<Report> reports = reportRepository.findAll(pageable);
 
-        return page.map(ReportSummaryRes::fromEntity);
+        return reports.map(ReportSummaryRes::fromEntity);
     }
 }

--- a/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
@@ -9,67 +9,69 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.user.dto.UserSortType;
 
 @Tag(name = "[관리자용 사용자 API]", description = "관리자용 사용자 관련 API")
 public interface AdminUserApi {
 
-    @Operation(summary = "전체 사용자 페이지별 최신순 조회", description = "전체 사용자를 페이지별로 조회하는 API입니다. 사용자는 최신순으로 조회됩니다.")
+    @Operation(summary = "전체 사용자 페이지별 조회", description = "전체 사용자를 정렬 기준에 따라 페이지별로 조회하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공",
                 content = @Content(mediaType = "application/json", examples = {
                     @ExampleObject(value = """
                         {
-                            "totalPages": 1,
-                            "totalElements": 3,
-                            "first": true,
-                            "last": true,
-                            "size": 10,
-                            "content": [
-                                {
-                                    "id": 8,
-                                    "username": "admin",
-                                    "nickname": "admin",
-                                    "email": "admin@gmail.com",
-                                    "createdAt": "2024-08-10T18:03:12.727292"
-                                },
-                                {
-                                    "id": 7,
-                                    "username": "test111",
-                                    "nickname": "테스터111",
-                                    "email": "test111@gmail.com",
-                                    "createdAt": "2024-08-10T02:13:51.658051"
-                                },
-                                {
-                                    "id": 1,
-                                    "username": "test",
-                                    "nickname": "테스터",
-                                    "email": "test@gmail.com",
-                                    "createdAt": "2024-08-05T03:25:02.974794"
-                                }
-                            ],
-                            "number": 0,
-                            "sort": {
-                                "empty": true,
-                                "unsorted": true,
-                                "sorted": false
-                            },
-                            "pageable": {
-                                "pageNumber": 0,
-                                "pageSize": 10,
-                                "sort": {
-                                    "empty": true,
-                                    "unsorted": true,
-                                    "sorted": false
-                                },
-                                "offset": 0,
-                                "unpaged": false,
-                                "paged": true
-                            },
-                            "numberOfElements": 3,
-                            "empty": false
+                             "totalPages": 1,
+                             "totalElements": 3,
+                             "first": true,
+                             "last": true,
+                             "size": 20,
+                             "content": [
+                                 {
+                                     "id": 1,
+                                     "username": "test",
+                                     "nickname": "테스터",
+                                     "email": "test@gmail.com",
+                                     "createdAt": "2024-08-05T03:25:02.974794"
+                                 },
+                                 {
+                                     "id": 7,
+                                     "username": "test111",
+                                     "nickname": "테스터111",
+                                     "email": "test111@gmail.com",
+                                     "createdAt": "2024-08-10T02:13:51.658051"
+                                 },
+                                 {
+                                     "id": 8,
+                                     "username": "admin",
+                                     "nickname": "admin",
+                                     "email": "admin@gmail.com",
+                                     "createdAt": "2024-08-10T18:03:12.727292"
+                                 }
+                             ],
+                             "number": 0,
+                             "sort": {
+                                 "empty": false,
+                                 "unsorted": false,
+                                 "sorted": true
+                             },
+                             "pageable": {
+                                 "pageNumber": 0,
+                                 "pageSize": 20,
+                                 "sort": {
+                                     "empty": false,
+                                     "unsorted": false,
+                                     "sorted": true
+                                 },
+                                 "offset": 0,
+                                 "unpaged": false,
+                                 "paged": true
+                             },
+                             "numberOfElements": 3,
+                             "empty": false
                         }
                     """)
             }))
     })
-    ResponseEntity<?> getUserPage(@RequestParam @Min(0) Integer page);
+    ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
+                                  @RequestParam @Min(0) Integer page);
 }

--- a/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
@@ -5,8 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 import yuquiz.domain.user.api.AdminUserApi;
+import yuquiz.domain.user.dto.UserSortType;
 import yuquiz.domain.user.dto.UserSummaryRes;
 import yuquiz.domain.user.service.AdminUserService;
 
@@ -18,9 +22,10 @@ public class AdminUserController implements AdminUserApi {
     private final AdminUserService adminUserService;
 
     @GetMapping
-    public ResponseEntity<?> getUserPage(@RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
+                                         @RequestParam @Min(0) Integer page) {
 
-        Page<UserSummaryRes> users = adminUserService.getUserPage(page);
+        Page<UserSummaryRes> users = adminUserService.getAllUsers(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(users);
     }

--- a/src/main/java/yuquiz/domain/user/dto/UserSortType.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserSortType.java
@@ -1,0 +1,28 @@
+package yuquiz.domain.user.dto;
+
+import org.springframework.data.domain.Sort;
+
+public enum UserSortType {
+    NICK_DESC("nickname", Sort.Direction.DESC),
+    NICK_ASC("nickname", Sort.Direction.ASC),
+    MAIL_DESC("email", Sort.Direction.DESC),
+    MAIL_ASC("email", Sort.Direction.ASC),
+    BAN_DESC("bannedCnt", Sort.Direction.DESC),
+    BAN_ASC("bannedCnt", Sort.Direction.ASC),
+    ROLE_DESC("role", Sort.Direction.DESC),
+    ROLE_ASC("role", Sort.Direction.ASC),
+    DATE_DESC("createdAt", Sort.Direction.DESC),
+    DATE_ASC("createdAt", Sort.Direction.ASC);
+
+    private String type;
+    private Sort.Direction direction;
+
+    UserSortType(String type, Sort.Direction direction) {
+        this.type = type;
+        this.direction = direction;
+    }
+
+    public Sort getSort() {
+        return Sort.by(direction, type);
+    }
+}

--- a/src/main/java/yuquiz/domain/user/service/AdminUserService.java
+++ b/src/main/java/yuquiz/domain/user/service/AdminUserService.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import yuquiz.domain.user.dto.UserSortType;
 import yuquiz.domain.user.dto.UserSummaryRes;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.repository.UserRepository;
@@ -15,12 +16,12 @@ public class AdminUserService {
 
     private final UserRepository userRepository;
 
-    private static final Integer USER_PER_PAGE = 10;
+    private static final Integer USER_PER_PAGE = 20;
 
-    public Page<UserSummaryRes> getUserPage(Integer page) {
+    public Page<UserSummaryRes> getAllUsers(UserSortType sort, Integer page) {
 
-        Pageable pageable = PageRequest.of(page, USER_PER_PAGE);
-        Page<User> users = userRepository.findAllByOrderByCreatedAtDesc(pageable);
+        Pageable pageable = PageRequest.of(page, USER_PER_PAGE, sort.getSort());
+        Page<User> users = userRepository.findAll(pageable);
 
         return users.map(UserSummaryRes::fromEntity);
     }


### PR DESCRIPTION
## 개요
관리자의 권한으로 게시글, 퀴즈, 신고, 사용자를 조회할 때 정렬 기준을 정할 수 있도록 추가하였습니다.

또한, 게시글, 퀴즈, 신고, 사용자에 대한 정렬 기준을 추가하였습니다.

메서드 명, Swagger 등을 통일성있게 바꾸었습니다.

테스트는 해보았지만 이전 테스트와 반환값에 있어 달라진 점이 거의 없어 첨부하지는 않았습니다.
(테스트는 정상 작동)

## 참고
기존 정렬기준을 Client가 전달하지 않았습니다.
즉, 내부적으로 Spring Data JPA를 활용하여 정렬하여 전달하였습니다.

이 경우 반환값에서 `"unsorted" : true, "sorted": false` 로 전달 되었습니다.

하지만 변경한 후로는 아래와 같이 `"sorted": true" 로 자동 변경되었습니다. 

(반환 json의 pageable에 해당하는 내용입니다. Swagger 코드 참고 바랍니다.)
```JSON
"sort": {
    "empty": false,
    "unsorted": false,
    "sorted": true
}
```

이는 Spring Data JPA에게 pageable을 전달할 때, 정렬기준을 정해서 전달해줬기 때문입니다.