### PR TITLE
feat: 퀴즈 채점 관련, 즐겨찾기, 좋아요 구현

### DIFF
--- a/src/main/java/yuquiz/domain/pinnedQuiz/entity/PinnedQuiz.java
+++ b/src/main/java/yuquiz/domain/pinnedQuiz/entity/PinnedQuiz.java
@@ -2,6 +2,7 @@ package yuquiz.domain.pinnedQuiz.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.domain.quiz.entity.Quiz;
@@ -23,4 +24,10 @@ public class PinnedQuiz {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_id")
     private Quiz quiz;
+
+    @Builder
+    public PinnedQuiz(User user, Quiz quiz) {
+        this.user = user;
+        this.quiz = quiz;
+    }
 }

--- a/src/main/java/yuquiz/domain/pinnedQuiz/exception/PinnedQuizExceptionCode.java
+++ b/src/main/java/yuquiz/domain/pinnedQuiz/exception/PinnedQuizExceptionCode.java
@@ -1,0 +1,23 @@
+package yuquiz.domain.pinnedQuiz.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum PinnedQuizExceptionCode implements ExceptionCode {
+
+    ALREADY_PINNED(409, "이미 즐겨찾기된 퀴즈입니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return this.status;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+}

--- a/src/main/java/yuquiz/domain/pinnedQuiz/repository/PinnedQuizRepository.java
+++ b/src/main/java/yuquiz/domain/pinnedQuiz/repository/PinnedQuizRepository.java
@@ -2,6 +2,11 @@ package yuquiz.domain.pinnedQuiz.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.pinnedQuiz.entity.PinnedQuiz;
+import yuquiz.domain.quiz.entity.Quiz;
+import yuquiz.domain.user.entity.User;
 
 public interface PinnedQuizRepository extends JpaRepository<PinnedQuiz, Long> {
+    void deleteByUserAndQuiz(User user, Quiz quiz);
+
+    boolean existsByUserAndQuiz(User user, Quiz quiz);
 }

--- a/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
@@ -153,6 +153,7 @@ public interface QuizApi {
                     }))
     })
     ResponseEntity<?> gradeQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
             @PathVariable(value = "quizId") Long quizId,
             @Valid @RequestBody AnswerReq answerReq);
 

--- a/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
+++ b/src/main/java/yuquiz/domain/quiz/api/QuizApi.java
@@ -242,7 +242,8 @@ public interface QuizApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> getQuizzesBySubject(@PathVariable(value = "subjectId") Long subjectId,
+    ResponseEntity<?> getQuizzesBySubject(@AuthenticationPrincipal SecurityUserDetails userDetails,
+                                          @PathVariable(value = "subjectId") Long subjectId,
                                           @RequestParam(value = "page") @Min(0) Integer page,
                                           @RequestParam(value = "sort") QuizSortType sort);
 
@@ -343,7 +344,8 @@ public interface QuizApi {
                                     """)
                     })),
     })
-    ResponseEntity<?> getQuizzesByKeyword(@RequestParam(value = "keyword") String keyword,
+    ResponseEntity<?> getQuizzesByKeyword(@AuthenticationPrincipal SecurityUserDetails userDetails,
+                                          @RequestParam(value = "keyword") String keyword,
                                           @RequestParam(value = "sort") QuizSortType sort,
                                           @RequestParam(value = "page") @Min(0) Integer page);
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.domain.quiz.api.AdminQuizApi;
+import yuquiz.domain.quiz.dto.AdminQuizSummaryRes;
 import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.service.AdminQuizService;
@@ -22,7 +23,7 @@ public class AdminQuizController implements AdminQuizApi {
     public ResponseEntity<?> getAllQuizzes(@RequestParam QuizSortType sort,
                                            @RequestParam @Min(0) Integer page) {
 
-        Page<QuizSummaryRes> quizzes = adminQuizService.getAllQuizzes(sort, page);
+        Page<AdminQuizSummaryRes> quizzes = adminQuizService.getAllQuizzes(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -54,9 +54,10 @@ public class QuizController implements QuizApi {
 
     @PostMapping("/{quizId}/grade")
     public ResponseEntity<?> gradeQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
             @PathVariable(value = "quizId") Long quizId,
             @Valid @RequestBody AnswerReq answerReq) {
-        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from(quizService.gradeQuiz(quizId, answerReq.answer())));
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from(quizService.gradeQuiz(userDetails.getId(), quizId, answerReq.answer())));
     }
 
     @GetMapping("/{quizId}/answer")

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -84,4 +84,24 @@ public class QuizController implements QuizApi {
         Page<QuizSummaryRes> quizzes = quizService.getQuizzesByKeyword(userDetails.getId(), keyword, sort, page);
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }
+
+    @PostMapping("/{quizId}/pin")
+    public ResponseEntity<?> pinQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @PathVariable(value = "quizId") Long quizId) {
+
+        quizService.pinQuiz(userDetails.getId(), quizId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 추가되었습니다."));
+    }
+
+    @DeleteMapping("/{quizId}/pin")
+    public ResponseEntity<?> deletePinQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @PathVariable(value = "quizId") Long quizId) {
+
+        quizService.deletePinQuiz(userDetails.getId(), quizId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -66,18 +66,22 @@ public class QuizController implements QuizApi {
     }
 
     @GetMapping("/subject/{subjectId}")
-    public ResponseEntity<?> getQuizzesBySubject(@PathVariable(value = "subjectId") Long subjectId,
-                                                 @RequestParam(value = "page") @Min(0) Integer page,
-                                                 @RequestParam(value = "sort") QuizSortType sort) {
-        Page<QuizSummaryRes> quizzes = quizService.getQuizzesBySubject(subjectId, sort, page);
+    public ResponseEntity<?> getQuizzesBySubject(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @PathVariable(value = "subjectId") Long subjectId,
+            @RequestParam(value = "page") @Min(0) Integer page,
+            @RequestParam(value = "sort") QuizSortType sort) {
+        Page<QuizSummaryRes> quizzes = quizService.getQuizzesBySubject(userDetails.getId(), subjectId, sort, page);
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }
 
     @GetMapping
-    public ResponseEntity<?> getQuizzesByKeyword(@RequestParam(value = "keyword") String keyword,
-                                                 @RequestParam(value = "sort") QuizSortType sort,
-                                                 @RequestParam(value = "page") @Min(0) Integer page) {
-        Page<QuizSummaryRes> quizzes = quizService.getQuizzesByKeyword(keyword, sort, page);
+    public ResponseEntity<?> getQuizzesByKeyword(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @RequestParam(value = "keyword") String keyword,
+            @RequestParam(value = "sort") QuizSortType sort,
+            @RequestParam(value = "page") @Min(0) Integer page) {
+        Page<QuizSummaryRes> quizzes = quizService.getQuizzesByKeyword(userDetails.getId(), keyword, sort, page);
         return ResponseEntity.status(HttpStatus.OK).body(quizzes);
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/QuizController.java
@@ -104,4 +104,24 @@ public class QuizController implements QuizApi {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @PostMapping("/{quizId}/likes")
+    public ResponseEntity<?> likeQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @PathVariable(value = "quizId") Long quizId) {
+
+        quizService.likeQuiz(userDetails.getId(), quizId);
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 추가되었습니다."));
+    }
+
+    @DeleteMapping("/{quizId}/likes")
+    public ResponseEntity<?> deleteLikeQuiz(
+            @AuthenticationPrincipal SecurityUserDetails userDetails,
+            @PathVariable(value = "quizId") Long quizId) {
+
+        quizService.deleteLikeQuiz(userDetails.getId(), quizId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
 }

--- a/src/main/java/yuquiz/domain/quiz/dto/AdminQuizSummaryRes.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/AdminQuizSummaryRes.java
@@ -5,24 +5,22 @@ import yuquiz.domain.triedQuiz.entity.TriedQuiz;
 
 import java.time.LocalDateTime;
 
-public record QuizSummaryRes(
+public record AdminQuizSummaryRes(
         Long quizId,
         String quizTitle,
         String nickname,
         LocalDateTime createdAt,
         Integer likeCount,
-        Integer viewCount,
-        Boolean isSolved
+        Integer viewCount
 ) {
-    public static QuizSummaryRes fromEntity(Quiz quiz, TriedQuiz triedQuiz) {
-        return new QuizSummaryRes(
+    public static AdminQuizSummaryRes fromEntity(Quiz quiz) {
+        return new AdminQuizSummaryRes(
                 quiz.getId(),
                 quiz.getTitle(),
                 quiz.getWriter().getNickname(),
                 quiz.getCreatedAt(),
                 quiz.getLikeCount(),
-                quiz.getViewCount(),
-                triedQuiz != null ? triedQuiz.getIsSolved() : null
+                quiz.getViewCount()
         );
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/AdminQuizService.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import yuquiz.domain.quiz.dto.AdminQuizSummaryRes;
 import yuquiz.domain.quiz.dto.QuizSortType;
 import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.entity.Quiz;
@@ -19,12 +20,12 @@ public class AdminQuizService {
 
     private static final Integer QUIZ_PER_PAGE = 20;
 
-    public Page<QuizSummaryRes> getAllQuizzes(QuizSortType sort, Integer page) {
+    public Page<AdminQuizSummaryRes> getAllQuizzes(QuizSortType sort, Integer page) {
 
         Pageable pageable = PageRequest.of(page, QUIZ_PER_PAGE, sort.getSort());
         Page<Quiz> quizzes = quizRepository.findAll(pageable);
 
-        return quizzes.map(QuizSummaryRes::fromEntity);
+        return quizzes.map(AdminQuizSummaryRes::fromEntity);
     }
 
     @Transactional

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -17,6 +17,9 @@ import yuquiz.domain.quiz.dto.QuizSummaryRes;
 import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quiz.exception.QuizExceptionCode;
 import yuquiz.domain.quiz.repository.QuizRepository;
+import yuquiz.domain.quizLike.entity.QuizLike;
+import yuquiz.domain.quizLike.exception.QuizLikeExceptionCode;
+import yuquiz.domain.quizLike.repository.QuizLikeRepository;
 import yuquiz.domain.report.dto.ReportReq;
 import yuquiz.domain.report.entity.Report;
 import yuquiz.domain.report.repository.ReportRepository;
@@ -38,6 +41,7 @@ public class QuizService {
     private final SubjectRepository subjectRepository;
     private final TriedQuizRepository triedQuizRepository;
     private final PinnedQuizRepository pinnedQuizRepository;
+    private final QuizLikeRepository quizLikeRepository;
 
     private static final Integer QUIZ_PER_PAGE = 20;
 
@@ -147,6 +151,31 @@ public class QuizService {
         Quiz quiz = findQuizByQuizId(quizId);
 
         pinnedQuizRepository.deleteByUserAndQuiz(user, quiz);
+    }
+
+    @Transactional
+    public void likeQuiz(Long userId, Long quizId) {
+        User user = findUserByUserId(userId);
+        Quiz quiz = findQuizByQuizId(quizId);
+
+        if (quizLikeRepository.existsByUserAndQuiz(user, quiz)) {
+            throw new CustomException(QuizLikeExceptionCode.ALREADY_EXIST);
+        }
+
+        QuizLike quizLike = QuizLike.builder()
+                .user(user)
+                .quiz(quiz)
+                .build();
+
+        quizLikeRepository.save(quizLike);
+    }
+
+    @Transactional
+    public void deleteLikeQuiz(Long userId, Long quizId) {
+        User user = findUserByUserId(userId);
+        Quiz quiz = findQuizByQuizId(quizId);
+
+        quizLikeRepository.deleteByUserAndQuiz(user, quiz);
     }
 
     private User findUserByUserId(Long userId) {

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -20,6 +20,8 @@ import yuquiz.domain.report.repository.ReportRepository;
 import yuquiz.domain.subject.entity.Subject;
 import yuquiz.domain.subject.exception.SubjectExceptionCode;
 import yuquiz.domain.subject.repository.SubjectRepository;
+import yuquiz.domain.triedQuiz.entity.TriedQuiz;
+import yuquiz.domain.triedQuiz.repository.TriedQuizRepository;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
@@ -31,7 +33,7 @@ public class QuizService {
     private final QuizRepository quizRepository;
     private final UserRepository userRepository;
     private final SubjectRepository subjectRepository;
-    private final ReportRepository reportRepository;
+    private final TriedQuizRepository triedQuizRepository;
 
     private static final Integer QUIZ_PER_PAGE = 20;
 
@@ -70,10 +72,20 @@ public class QuizService {
         return QuizRes.fromEntity(quiz);
     }
 
-    public boolean gradeQuiz(Long quizId, String answer) {
+    @Transactional
+    public boolean gradeQuiz(Long userId, Long quizId, String answer) {
         Quiz quiz = findQuizByQuizId(quizId);
+        User user = findUserByUserId(userId);
 
-        return quiz.getAnswer().equals(answer);
+        boolean isSolved = quiz.getAnswer().equals(answer);
+
+        TriedQuiz triedQuiz = triedQuizRepository.findByUserAndQuiz(user, quiz)
+                .orElse(new TriedQuiz(isSolved, user, quiz));
+
+        triedQuiz.updateIsSolved(isSolved);
+        triedQuizRepository.save(triedQuiz);
+
+        return isSolved;
     }
 
     public String getAnswer(Long quizId) {

--- a/src/main/java/yuquiz/domain/quizLike/entity/QuizLike.java
+++ b/src/main/java/yuquiz/domain/quizLike/entity/QuizLike.java
@@ -2,6 +2,7 @@ package yuquiz.domain.quizLike.entity;
 
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.domain.quiz.entity.Quiz;
@@ -23,4 +24,10 @@ public class QuizLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "quiz_id")
     private Quiz quiz;
+
+    @Builder
+    public QuizLike(User user, Quiz quiz) {
+        this.user = user;
+        this.quiz = quiz;
+    }
 }

--- a/src/main/java/yuquiz/domain/quizLike/exception/QuizLikeExceptionCode.java
+++ b/src/main/java/yuquiz/domain/quizLike/exception/QuizLikeExceptionCode.java
@@ -1,0 +1,23 @@
+package yuquiz.domain.quizLike.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum QuizLikeExceptionCode implements ExceptionCode {
+
+    ALREADY_EXIST(409, "이미 좋아요한 퀴즈입니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/yuquiz/domain/quizLike/repository/QuizLikeRepository.java
+++ b/src/main/java/yuquiz/domain/quizLike/repository/QuizLikeRepository.java
@@ -1,7 +1,12 @@
 package yuquiz.domain.quizLike.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quizLike.entity.QuizLike;
+import yuquiz.domain.user.entity.User;
 
 public interface QuizLikeRepository extends JpaRepository<QuizLike, Long> {
+    void deleteByUserAndQuiz(User user, Quiz quiz);
+
+    boolean existsByUserAndQuiz(User user, Quiz quiz);
 }

--- a/src/main/java/yuquiz/domain/triedQuiz/entity/TriedQuiz.java
+++ b/src/main/java/yuquiz/domain/triedQuiz/entity/TriedQuiz.java
@@ -29,7 +29,13 @@ public class TriedQuiz {
     private Quiz quiz;
 
     @Builder
-    public TriedQuiz(Boolean isSolved) {
+    public TriedQuiz(Boolean isSolved, User user, Quiz quiz) {
+        this.isSolved = isSolved;
+        this.user = user;
+        this.quiz = quiz;
+    }
+
+    public void updateIsSolved(boolean isSolved) {
         this.isSolved = isSolved;
     }
 }

--- a/src/main/java/yuquiz/domain/triedQuiz/repository/TriedQuizRepository.java
+++ b/src/main/java/yuquiz/domain/triedQuiz/repository/TriedQuizRepository.java
@@ -1,7 +1,14 @@
 package yuquiz.domain.triedQuiz.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.triedQuiz.entity.TriedQuiz;
+import yuquiz.domain.user.entity.User;
+
+import java.util.Optional;
 
 public interface TriedQuizRepository extends JpaRepository<TriedQuiz, Long> {
+    boolean existsByUserAndQuiz(User user, Quiz quiz);
+
+    Optional<TriedQuiz> findByUserAndQuiz(User user, Quiz quiz);
 }


### PR DESCRIPTION
## 개요
퀴즈의 남은 기능들을 구현하였습니다.

## 구현사항
* 퀴즈 채점시 tiredQuiz에 엔티티 추가
  * 이미 풀었던 문제면 isSolved만 수정 -> `이건 정답이면 수정 안되도록 하는게 맞을까요? (현재는 정답이라도 다시 틀리면 틀린걸로 바뀜)`
* 퀴즈 목록 불러오기 시 채점 여부 같이 보내기 -> 이건 어드민 목록은 안불러오는게 맞는 것 같아서 dto를 분리했습니다
  * 맞았으면 isSolve가 true, 틀렸으면 false, 푼 기록이 없다면 null 로 보냄
* 퀴즈 즐겨찾기 기능
* 퀴즈 좋아요 기능

## 테스트
1. 퀴즈 채점
![image](https://github.com/user-attachments/assets/6083d430-cd8e-4119-9416-206676c5fe35)
<img width="584" alt="image" src="https://github.com/user-attachments/assets/657d94ed-5c8e-41e2-a8ef-f523e295ee82">

2. 퀴즈 목록
<img width="630" alt="image" src="https://github.com/user-attachments/assets/e993946d-a531-488e-aea9-4b81ac474f8f">


3. 퀴즈 즐겨찾기
<img width="594" alt="image" src="https://github.com/user-attachments/assets/a7aa4145-4339-4803-878b-1639e3b53f84">

중복 즐겨찾기 추가 불가능
<img width="598" alt="image" src="https://github.com/user-attachments/assets/28eedad8-8f95-4f70-8f87-335adb44c34b">

4. 퀴즈 좋아요
즐겨찾기와 동일
<img width="590" alt="image" src="https://github.com/user-attachments/assets/18b61d2f-4081-4795-91a3-1ce29ada4f6c">
<img width="590" alt="image" src="https://github.com/user-attachments/assets/0613c6e7-dfec-4606-9767-6ba4bcde2165">

즐겨찾기와 좋아요 모두 삭제 기능 까지 구현했습니다.
Swagger는 추후 작성하도록 하겠습니다.