### PR TITLE
feat: 관리자용 사용자 강제 정지, 강제 탈퇴 기능 추가

### DIFF
--- a/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
@@ -77,6 +77,12 @@ public interface AdminUserApi {
     ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
                                   @RequestParam @Min(0) Integer page);
 
+    @Operation(summary = "사용자 강제 탈퇴", description = "사용자id를 기반으로 사용자를 탈퇴시키는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "사용자 탈퇴 성공")
+    })
+    ResponseEntity<?> deleteUser(@PathVariable Long userId);
+
     @Operation(summary = "사용자 정지, 사면, 취소", description = "사용자 강제 정지, 정지 사면, 정지 취소 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "사용자 정지 성공",

--- a/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import yuquiz.domain.user.dto.UserSortType;
+import yuquiz.domain.user.dto.UserStatusReq;
 
 @Tag(name = "[관리자용 사용자 API]", description = "관리자용 사용자 관련 API")
 public interface AdminUserApi {
@@ -74,4 +76,43 @@ public interface AdminUserApi {
     })
     ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
                                   @RequestParam @Min(0) Integer page);
+
+    @Operation(summary = "사용자 정지, 사면, 취소", description = "사용자 강제 정지, 정지 사면, 정지 취소 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "사용자 정지 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "response": "회원 정지 성공"
+                        }
+                    """)
+            })),
+            @ApiResponse(responseCode = "200", description = "사용자 사면 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "response": "회원 사면 성공"
+                        }
+                    """)
+            })),
+            @ApiResponse(responseCode = "200", description = "사용자 정지 취소 성공",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "response": "회원 정지 취소 성공"
+                        }
+                    """)
+            })),
+            @ApiResponse(responseCode = "404", description = "사용자 존재하지 않음",
+                content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                        {
+                            "status": 404,
+                            "message": "존재하지 않는 사용자입니다."
+                        }
+                    """)
+            }))
+    })
+    ResponseEntity<?> suspendUser(@PathVariable Long userId,
+                                  @RequestParam UserStatusReq status);
 }

--- a/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
+++ b/src/main/java/yuquiz/domain/user/api/AdminUserApi.java
@@ -11,7 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import yuquiz.domain.user.dto.UserSortType;
-import yuquiz.domain.user.dto.UserStatusReq;
+import yuquiz.domain.user.dto.req.UserStatusReq;
 
 @Tag(name = "[관리자용 사용자 API]", description = "관리자용 사용자 관련 API")
 public interface AdminUserApi {

--- a/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
@@ -5,13 +5,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.user.api.AdminUserApi;
 import yuquiz.domain.user.dto.res.UserSummaryRes;
 import yuquiz.domain.user.dto.UserSortType;
+import yuquiz.domain.user.dto.req.UserStatusReq;
 import yuquiz.domain.user.service.AdminUserService;
 
 @RestController
@@ -21,6 +20,7 @@ public class AdminUserController implements AdminUserApi {
 
     private final AdminUserService adminUserService;
 
+    @Override
     @GetMapping
     public ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
                                          @RequestParam @Min(0) Integer page) {
@@ -28,5 +28,19 @@ public class AdminUserController implements AdminUserApi {
         Page<UserSummaryRes> users = adminUserService.getAllUsers(sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(users);
+    }
+
+    @Override
+    @PatchMapping("/{userId}")
+    public ResponseEntity<?> suspendUser(@PathVariable Long userId,
+                                         @RequestParam UserStatusReq status){
+
+        adminUserService.updateSuspendStatus(userId, status);
+
+        return switch (status) {
+            case SUSPEND -> ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("회원 정지 성공"));
+            case UNSUSPEND -> ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("회원 사면 성공"));
+            case CANCEL -> ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("회원 정지 취소 성공"));
+        };
     }
 }

--- a/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
@@ -30,6 +30,14 @@ public class AdminUserController implements AdminUserApi {
         return ResponseEntity.status(HttpStatus.OK).body(users);
     }
 
+    @DeleteMapping("/{userId}")
+    public ResponseEntity<?> deleteUser(@PathVariable Long userId) {
+
+        adminUserService.deleteUser(userId);
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
     @Override
     @PatchMapping("/{userId}")
     public ResponseEntity<?> suspendUser(@PathVariable Long userId,

--- a/src/main/java/yuquiz/domain/user/dto/UserStatusReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserStatusReq.java
@@ -1,0 +1,10 @@
+package yuquiz.domain.user.dto;
+
+import lombok.Getter;
+
+@Getter
+public enum UserStatusReq {
+    SUSPEND,
+    UNSUSPEND,
+    CANCEL;
+}

--- a/src/main/java/yuquiz/domain/user/dto/UserStatusReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/UserStatusReq.java
@@ -6,5 +6,5 @@ import lombok.Getter;
 public enum UserStatusReq {
     SUSPEND,
     UNSUSPEND,
-    CANCEL;
+    CANCEL
 }

--- a/src/main/java/yuquiz/domain/user/dto/req/UserStatusReq.java
+++ b/src/main/java/yuquiz/domain/user/dto/req/UserStatusReq.java
@@ -1,4 +1,4 @@
-package yuquiz.domain.user.dto;
+package yuquiz.domain.user.dto.req;
 
 import lombok.Getter;
 

--- a/src/main/java/yuquiz/domain/user/entity/SuspendDay.java
+++ b/src/main/java/yuquiz/domain/user/entity/SuspendDay.java
@@ -1,0 +1,25 @@
+package yuquiz.domain.user.entity;
+
+import lombok.Getter;
+
+@Getter
+public enum SuspendDay {
+    FIRST(1), SECOND(3), THIRD(5), FOURTH(7), FIFTH(10), MORE(15);
+
+    private final int day;
+
+    SuspendDay(int day) {
+        this.day = day;
+    }
+
+    public static int getDay(int bannedCnt) {
+        return switch (bannedCnt){
+            case 1 -> SuspendDay.FIRST.getDay();
+            case 2 -> SuspendDay.SECOND.getDay();
+            case 3 -> SuspendDay.THIRD.getDay();
+            case 4 -> SuspendDay.FOURTH.getDay();
+            case 5 -> SuspendDay.FIFTH.getDay();
+            default -> SuspendDay.MORE.getDay();
+        };
+    }
+}

--- a/src/main/java/yuquiz/domain/user/entity/User.java
+++ b/src/main/java/yuquiz/domain/user/entity/User.java
@@ -24,6 +24,7 @@ import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quizLike.entity.QuizLike;
 import yuquiz.domain.triedQuiz.entity.TriedQuiz;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -59,6 +60,9 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "banned_cnt")
     private int bannedCnt;
+
+    @Column(name = "unlocked_at")
+    private LocalDateTime unlockedAt;
 
     @Enumerated(EnumType.STRING)
     private Role role;
@@ -115,5 +119,11 @@ public class User extends BaseTimeEntity {
     /* 비밀번호 변경 편의 메서드 */
     public void updatePassword(String newPassword) {
         this.password = newPassword;
+    }
+
+    /* 사용자 정지 상태 조작 메서드 */
+    public void updateSuspendStatus(LocalDateTime unlockedAt, int bannedCnt){
+        this.unlockedAt = unlockedAt;
+        this.bannedCnt = bannedCnt;
     }
 }

--- a/src/main/java/yuquiz/domain/user/service/AdminUserService.java
+++ b/src/main/java/yuquiz/domain/user/service/AdminUserService.java
@@ -5,10 +5,14 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import yuquiz.common.exception.CustomException;
 import yuquiz.domain.user.dto.res.UserSummaryRes;
 import yuquiz.domain.user.dto.UserSortType;
 import yuquiz.domain.user.entity.User;
+import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
+
+import java.time.LocalDateTime;
 
 @Service
 @RequiredArgsConstructor
@@ -24,5 +28,47 @@ public class AdminUserService {
         Page<User> users = userRepository.findAll(pageable);
 
         return users.map(UserSummaryRes::fromEntity);
+    }
+
+    public void updateSuspendStatus(Long userId, UserStatusReq status) {
+
+        User user = userRepository.findById(userId).orElseThrow(() ->
+                new CustomException(UserExceptionCode.INVALID_USERID));
+
+        switch (status) {
+            case SUSPEND -> suspendUser(user);
+            case UNSUSPEND -> unsuspendUser(user);
+            case CANCEL -> cancelSuspendUser(user);
+        }
+    }
+
+    private void suspendUser(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime unlockedAt = user.getUnlockedAt();
+        int bannedCnt = user.getBannedCnt();
+
+        if(unlockedAt == null || unlockedAt.isBefore(now)) {
+            user.updateSuspendStatus(now.plusDays(SuspendDay.getDay(bannedCnt)), bannedCnt + 1);
+        }
+    }
+
+    private void unsuspendUser(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime unlockedAt = user.getUnlockedAt();
+        int bannedCnt = user.getBannedCnt();
+
+        if(unlockedAt.isAfter(now)) {
+            user.updateSuspendStatus(now, bannedCnt);
+        }
+    }
+
+    private void cancelSuspendUser(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime unlockedAt = user.getUnlockedAt();
+        int bannedCnt = user.getBannedCnt();
+
+        if(unlockedAt.isAfter(now)) {
+            user.updateSuspendStatus(now, bannedCnt - 1);
+        }
     }
 }

--- a/src/main/java/yuquiz/domain/user/service/AdminUserService.java
+++ b/src/main/java/yuquiz/domain/user/service/AdminUserService.java
@@ -30,6 +30,11 @@ public class AdminUserService {
         return users.map(UserSummaryRes::fromEntity);
     }
 
+    public void deleteUser(Long userId) {
+
+        userRepository.deleteById(userId);
+    }
+
     public void updateSuspendStatus(Long userId, UserStatusReq status) {
 
         User user = userRepository.findById(userId).orElseThrow(() ->

--- a/src/main/java/yuquiz/domain/user/service/AdminUserService.java
+++ b/src/main/java/yuquiz/domain/user/service/AdminUserService.java
@@ -1,5 +1,7 @@
 package yuquiz.domain.user.service;
 
+import jakarta.persistence.Table;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -35,19 +37,21 @@ public class AdminUserService {
         userRepository.deleteById(userId);
     }
 
+    @Transactional
     public void updateSuspendStatus(Long userId, UserStatusReq status) {
 
-        User user = userRepository.findById(userId).orElseThrow(() ->
-                new CustomException(UserExceptionCode.INVALID_USERID));
-
         switch (status) {
-            case SUSPEND -> suspendUser(user);
-            case UNSUSPEND -> unsuspendUser(user);
-            case CANCEL -> cancelSuspendUser(user);
+            case SUSPEND -> suspendUser(userId);
+            case UNSUSPEND -> unsuspendUser(userId);
+            case CANCEL -> cancelSuspendUser(userId);
         }
     }
 
-    private void suspendUser(User user) {
+    private void suspendUser(Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(()->
+                new CustomException(UserExceptionCode.INVALID_USERID));
+
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime unlockedAt = user.getUnlockedAt();
         int bannedCnt = user.getBannedCnt();
@@ -57,22 +61,30 @@ public class AdminUserService {
         }
     }
 
-    private void unsuspendUser(User user) {
+    private void unsuspendUser(Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(()->
+                new CustomException(UserExceptionCode.INVALID_USERID));
+
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime unlockedAt = user.getUnlockedAt();
         int bannedCnt = user.getBannedCnt();
 
-        if(unlockedAt.isAfter(now)) {
+        if(unlockedAt != null && unlockedAt.isAfter(now)) {
             user.updateSuspendStatus(now, bannedCnt);
         }
     }
 
-    private void cancelSuspendUser(User user) {
+    private void cancelSuspendUser(Long userId) {
+
+        User user = userRepository.findById(userId).orElseThrow(()->
+                new CustomException(UserExceptionCode.INVALID_USERID));
+
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime unlockedAt = user.getUnlockedAt();
         int bannedCnt = user.getBannedCnt();
 
-        if(unlockedAt.isAfter(now)) {
+        if(unlockedAt != null && unlockedAt.isAfter(now)) {
             user.updateSuspendStatus(now, bannedCnt - 1);
         }
     }

--- a/src/main/java/yuquiz/domain/user/service/AdminUserService.java
+++ b/src/main/java/yuquiz/domain/user/service/AdminUserService.java
@@ -1,6 +1,5 @@
 package yuquiz.domain.user.service;
 
-import jakarta.persistence.Table;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -8,8 +7,10 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import yuquiz.common.exception.CustomException;
+import yuquiz.domain.user.dto.req.UserStatusReq;
 import yuquiz.domain.user.dto.res.UserSummaryRes;
 import yuquiz.domain.user.dto.UserSortType;
+import yuquiz.domain.user.entity.SuspendDay;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;


### PR DESCRIPTION
## 개요
관리자용 기능입니다.

관리자용 사용자 강제 정지, 강제 탈퇴 기능을 추가하였습니다.

## 구현기능
- 사용자 강제 정지
- 사용자 정지 사면 (아직 풀릴 시점이 되지 않았지만 풀어주는 경우)
- 사용자 정지 취소 (실수로 정지 시켰을 때 되돌리는 경우)
- 사용자 강제 탈퇴

(추가로, 필터 기능을 추가하여야 합니다. 정지상태인 사용자를 접속하지 못하도록 해야합니다. 추후에 업데이트 예정)

## 테스트
1. 사용자 강제 정지

<img width="854" alt="스크린샷 2024-08-14 오전 1 55 23" src="https://github.com/user-attachments/assets/69cf5bae-2d90-448d-81c7-8e47f96a68bc">

2. 사용자 정지 사면

<img width="854" alt="스크린샷 2024-08-14 오전 2 31 47" src="https://github.com/user-attachments/assets/30a45e51-95ce-4717-899b-53749479e870">

3. 사용자 정지 취소

<img width="846" alt="스크린샷 2024-08-14 오전 2 00 39" src="https://github.com/user-attachments/assets/2ff65210-cdd4-4c8e-9aef-0f335fa4e3c0">

4. 사용자 강제 탈퇴

<img width="854" alt="스크린샷 2024-08-14 오전 2 33 01" src="https://github.com/user-attachments/assets/4c6cc914-27d9-425b-9bf0-21fdbb53e53f">

5. 강제 정지, 사면, 취소에 대한 실패 (사용자 존재하지 않음)

<img width="848" alt="스크린샷 2024-08-14 오전 2 35 06" src="https://github.com/user-attachments/assets/4940b65c-e649-4bf4-bec7-5da6ac6b0fe2">

