### PR TITLE
feat: 퀴즈 조회 시 작성자 여부 전송

### DIFF
--- a/src/main/java/yuquiz/domain/quiz/dto/QuizRes.java
+++ b/src/main/java/yuquiz/domain/quiz/dto/QuizRes.java
@@ -29,9 +29,11 @@ public record QuizRes(
 
         boolean isLiked,
 
-        boolean isPinned
+        boolean isPinned,
+
+        boolean isWriter
 ) {
-    public static QuizRes fromEntity(Quiz quiz, boolean isLiked, boolean isPinned) {
+    public static QuizRes fromEntity(Quiz quiz, boolean isLiked, boolean isPinned, boolean isWriter) {
         return new QuizRes(
                 quiz.getTitle(),
                 quiz.getQuestion(),
@@ -44,7 +46,8 @@ public record QuizRes(
                 quiz.getWriter().getNickname(),
                 quiz.getCreatedAt(),
                 isLiked,
-                isPinned
+                isPinned,
+                isWriter
         );
     }
 }

--- a/src/main/java/yuquiz/domain/quiz/service/QuizService.java
+++ b/src/main/java/yuquiz/domain/quiz/service/QuizService.java
@@ -56,7 +56,7 @@ public class QuizService {
     @Transactional
     public void deleteQuiz(Long quizId, Long userId) {
 
-        if (!isWriter(quizId, userId)) {
+        if (!validateWriter(quizId, userId)) {
             throw new CustomException(QuizExceptionCode.UNAUTHORIZED_ACTION);
         }
 
@@ -66,7 +66,7 @@ public class QuizService {
     @Transactional
     public void updateQuiz(Long quizId, QuizReq quizReq, Long userId) {
 
-        if (!isWriter(quizId, userId)) {
+        if (!validateWriter(quizId, userId)) {
             throw new CustomException(QuizExceptionCode.UNAUTHORIZED_ACTION);
         }
 
@@ -86,10 +86,11 @@ public class QuizService {
 
         boolean isLiked = likedQuizRepository.existsByUserAndQuiz(user, quiz);
         boolean isPinned = pinnedQuizRepository.existsByUserAndQuiz(user, quiz);
+        boolean isWriter = validateWriter(quizId, userId);
 
         quiz.increaseViewCount();
 
-        return QuizRes.fromEntity(quiz, isLiked, isPinned);
+        return QuizRes.fromEntity(quiz, isLiked, isPinned, isWriter);
     }
 
     @Transactional
@@ -145,7 +146,7 @@ public class QuizService {
                 .orElseThrow(() -> new CustomException(QuizExceptionCode.INVALID_ID));
     }
 
-    private boolean isWriter(Long quizId, Long userId) {
+    private boolean validateWriter(Long quizId, Long userId) {
         return quizRepository.findWriterById(quizId)
                 .map(writerId -> writerId.equals(userId))
                 .orElse(false);


### PR DESCRIPTION
## 개요
퀴즈 조회 시 작성자 여부 전송

## 구현사항
퀴즈 조회 시 작성자만 수정, 삭제를 할 수 있게 하기 위해
퀴즈를 조회할 때, 해당 사용자가 퀴즈의 작성자인지 확인하는
isWriter를 추가하였습니다.

## 테스트
<img width="577" alt="image" src="https://github.com/user-attachments/assets/ba2c1b3f-5364-4282-bd6d-bd3f82bcc80d">
