### PR TITLE
refact: 비활성화된 퀴즈 퀴즈 목록에서 제외

### DIFF
--- a/src/main/java/yuquiz/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/yuquiz/domain/quiz/repository/QuizRepository.java
@@ -18,9 +18,9 @@ public interface QuizRepository extends JpaRepository<Quiz, Long> {
 
     @Query("SELECT q FROM Quiz q WHERE "
             + "(:keyword IS NULL OR q.title LIKE %:keyword% OR q.question LIKE %:keyword%) "
-            + "AND (:subjectId IS NULL OR q.subject.id = :subjectId)")
+            + "AND (:subjectId IS NULL OR q.subject.id = :subjectId) "
+            + "AND q.visibility = true")
     Page<Quiz> findQuizzesByKeywordAndSubject(@Param("keyword") String keyword, @Param("subjectId") Long subjectId, Pageable pageable);
-
     Page<Quiz> findAllByWriter(User writer, Pageable pageable);
 
     @Query("select q.writer.id from Quiz q where q.id = :id")


### PR DESCRIPTION
## 개요
기존에 신고 누적으로 인해 비활성화 된 퀴즈도 퀴즈 목록 조회 시 같이 조회되는 문제가 있었음

## 구현사항
신고 누적으로 인한 퀴즈 비활성화 시 퀴즈 조회에 조회되지 않도록 수정함.

## 테스트
비활성화 되기 전
<img width="627" alt="image" src="https://github.com/user-attachments/assets/eeece723-d317-4e21-8374-4129c7a067a3">

비활성화 후
<img width="649" alt="image" src="https://github.com/user-attachments/assets/926d25cb-0bc8-4363-8223-a9b3f2ef3b84">

