### PR TITLE
refact: 불필요한 반복 삭제

### DIFF
--- a/src/main/java/yuquiz/domain/notification/service/NotificationService.java
+++ b/src/main/java/yuquiz/domain/notification/service/NotificationService.java
@@ -79,11 +79,10 @@ public class NotificationService {
         String userId = String.valueOf(user.getId());
 
         Map<String, SseEmitter> sseEmitters = emitterRepository.findAllEmitterStartWithByUserId(userId);
+        String eventId = userId+"_"+System.currentTimeMillis();
+        emitterRepository.saveEventCache(eventId, NotificationRes.fromEntity(notification));
         sseEmitters.forEach(
                 (key, emitter) -> {
-                    String eventId = userId+"_"+System.currentTimeMillis();
-
-                    emitterRepository.saveEventCache(eventId, NotificationRes.fromEntity(notification));
                     sendClient(emitter, eventId, NotificationRes.fromEntity(notification));
                 }
         );


### PR DESCRIPTION
## 개요
event를 eventCache에 저장할 때 불필요한 반복을 삭제하였습니다.

## 구현사항
기존에 알림을 보내는 과정에서 eventCache에 event를 저장할 때,
emitter의 개수만큼 반복하는 과정이 있었습니다.

해당 로직을 반복문 밖으로 빼내어 한번만 실행되도록 하였습니다.

