### PR TITLE
feat: s3 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 }
 
 tasks.named('test') {

--- a/src/main/java/yuquiz/common/s3/ImageType.java
+++ b/src/main/java/yuquiz/common/s3/ImageType.java
@@ -1,2 +1,5 @@
-package yuquiz.common.s3;public enum ImageType {
+package yuquiz.common.s3;
+
+public enum ImageType {
+    QUIZ
 }

--- a/src/main/java/yuquiz/common/s3/ImageType.java
+++ b/src/main/java/yuquiz/common/s3/ImageType.java
@@ -1,0 +1,2 @@
+package yuquiz.common.s3;public enum ImageType {
+}

--- a/src/main/java/yuquiz/common/s3/service/StorageService.java
+++ b/src/main/java/yuquiz/common/s3/service/StorageService.java
@@ -1,2 +1,77 @@
-package yuquiz.common.s3.service;public class StroageSercice {
+package yuquiz.common.s3.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import yuquiz.common.s3.ImageType;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+@Service
+public class StorageService {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket-name}")
+    private String bucket;
+
+    // 이미지 업로드
+    public String uploadImage(MultipartFile file, Long id, ImageType type) {
+        String fileName = generateFileName(id, file.getOriginalFilename(), type);
+        ObjectMetadata metadata = createObjectMetadata(file);
+
+        uploadToS3(file, fileName, metadata);
+
+        return getFileUrl(fileName);
+    }
+
+    // 이미지 삭제
+    public void deleteImage(String imageUrl) {
+        String fileName = extractFileNameFromUrl(imageUrl);
+        amazonS3.deleteObject(bucket, fileName);
+    }
+
+    // 파일 이름 생성 (id(PK)와 UUID 기반)
+    private String generateFileName(Long id, String originalFileName, ImageType type) {
+        String dir = "";
+        switch (type) {
+            case QUIZ -> dir = "quiz/";
+        }
+
+        return dir + id + "/" + UUID.randomUUID() + "-" + originalFileName;
+    }
+
+    // S3 업로드
+    private void uploadToS3(MultipartFile file, String fileName, ObjectMetadata metadata) {
+        try {
+            amazonS3.putObject(new PutObjectRequest(bucket, fileName, file.getInputStream(), metadata));
+        } catch (IOException e) {
+            throw new IllegalArgumentException("이미지 저장 중 오류 발생.");
+        }
+    }
+
+    // 메타데이터 생성
+    private ObjectMetadata createObjectMetadata(MultipartFile file) {
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(file.getContentType());
+        metadata.setContentLength(file.getSize());
+        return metadata;
+    }
+
+    // 파일 URL 가져오기
+    private String getFileUrl(String fileName) {
+        return amazonS3.getUrl(bucket, fileName).toString();
+    }
+
+    // 이미지 URL에서 파일 이름 추출
+    private String extractFileNameFromUrl(String imageUrl) {
+        int startIndex = imageUrl.indexOf("/", imageUrl.indexOf("//") + 2);
+        return imageUrl.substring(startIndex + 1);
+    }
 }

--- a/src/main/java/yuquiz/common/s3/service/StorageService.java
+++ b/src/main/java/yuquiz/common/s3/service/StorageService.java
@@ -1,0 +1,2 @@
+package yuquiz.common.s3.service;public class StroageSercice {
+}

--- a/src/main/java/yuquiz/config/AmazonS3Config.java
+++ b/src/main/java/yuquiz/config/AmazonS3Config.java
@@ -1,0 +1,31 @@
+package yuquiz.config;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AmazonS3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3 s3Client() {
+        AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+        return AmazonS3ClientBuilder.standard()
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .withRegion(region).build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,11 @@ spring:
             enable: true
             trust: smtp.naver.com
 
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB
+
 jwt:
   secret: ${JWT_KEY:exampleSecretKeyForYUQuizSystemAccessSecretKeyTestForPadding}
   access-expiration: ${JWT_ACCESS_EXPIRATION:1800000}
@@ -74,3 +79,15 @@ oauth2:
     clientSecret: ${NAVER_CLIENT_SECRET}
     redirectUri: ${NAVER_REDIRECT_URL}
     getUserInfoUri: https://openapi.naver.com/v1/nid/me
+
+cloud:
+  aws:
+    credentials:
+      access-key: ${AWS_ACCESS_KEY}
+      secret-key: ${AWS_SECRET_KEY}
+    region:
+      static: ${AWS_REGION}
+    stack:
+      auto: false
+    s3:
+      bucket-name: ${S3_BUCKET_NAME}


### PR DESCRIPTION
## 개요
퀴즈 이미지를 위한 Amazon S3 연결

## 구현사항
- S3 설정
- 이미지 저장, 삭제 구현
- 이미지 전송 가능 사이즈 10MB로 임시 설정

## 기타
 - 이미지 크기 같은 경우에는 1MB가 기본 설정이기 때문에, application\.yml에서 서블릿 설정을 함. (사용자들이 10MB까지 쓰는 경우는 없겠지만, 찝찝하다면 원하는 크기 있으면 말해주세요)
 - 백엔드에서 이미지 저장 및 삭제 모두 처리할 것이기 때문에, 프론트에서는 이미지 자체를 보내 백엔드에서 `MultipartFile`로 받으시면 됩니다. (프론트에서도 aws 키값을 관리하면 보안적인 이유 때문.)
 - ImageType을 설정했는데, Quiz외에 이미지 추가가 생길 가능성 때문에 만들어 놨습니다. (이미지마다 따로 관리하기 위함)