### PR TITLE
refact: 인증 등록과정 수정

### DIFF
--- a/src/main/java/yuquiz/common/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/yuquiz/common/jwt/filter/JwtAuthenticationFilter.java
@@ -79,9 +79,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     /* Authentication 가져오기 */
     private Authentication getAuthentication(String token) {
 
-        String username = jwtProvider.getUsername(token);
+        String userId = String.valueOf(jwtProvider.getUserId(token));
 
-        UserDetails userDetails = userDetailsService.loadUserByUsername(username);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(userId);
 
         return new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
     }

--- a/src/main/java/yuquiz/security/auth/UserDetailServiceImpl.java
+++ b/src/main/java/yuquiz/security/auth/UserDetailServiceImpl.java
@@ -16,15 +16,15 @@ public class UserDetailServiceImpl implements UserDetailsService {
     private final UserRepository userRepository;
 
     @Override
-    @Cacheable(value = "users", key = "#username")
-    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+    @Cacheable(value = "users", key = "#userId")
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
 
-        if(username == null || username.equals("")) {
-            throw new UsernameNotFoundException(username);
+        if (userId == null || userId.equals("")) {
+            throw new UsernameNotFoundException(userId);
         }
 
-        User foundUser = userRepository.findByUsername(username).orElseThrow(() ->
-                new UsernameNotFoundException("User not found with username: " + username));
+        User foundUser = userRepository.findById(Long.valueOf(userId)).orElseThrow(() ->
+                new UsernameNotFoundException("User not found with username: " + userId));
 
         return new SecurityUserDetails(foundUser);
     }


### PR DESCRIPTION
## 개요
SecurityContextHolder에 인증된 사용자의 정보를 등록하는 과정 중, 캐싱을 이용한다.
username으로 캐싱을 등록하게 되면,
 만약 사용자가 탈퇴를 하고 바로 같은 아이디로 가입을 하는 과정에서 그 전의 값을 불러오기 때문에 오류가 발생한다.
이를 위해 username이 아닌 userId를 통해 받아온다.

## 구현사항
 - username에서 userId로 변경

## 기타
동작하는 과정은 이전과 같습니다. `개요`에 적힌 이유때문에 username에서 userId로 바꾼 것 뿐입니다.