### PR TITLE
feat: 스터디 수정, 목록 조회 기능 구현

### DIFF
--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -2,13 +2,19 @@ package yuquiz.domain.study.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.study.api.StudyApi;
+import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
+import yuquiz.domain.study.dto.StudySortType;
+import yuquiz.domain.study.dto.StudySummaryRes;
 import yuquiz.domain.study.service.StudyService;
 import yuquiz.security.auth.SecurityUserDetails;
 
@@ -45,5 +51,16 @@ public class StudyController implements StudyApi {
         studyService.updateStudy(studyReq, studyId, userDetails.getId());
 
         return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 수정되었습니다."));
+    }
+
+    @GetMapping
+    public ResponseEntity<?> getStudies(@RequestParam(value = "keyword", required = false) String keyword,
+                                        @RequestParam(value = "sort", defaultValue = "CREATED_DESC") StudySortType sort,
+                                        @RequestParam(value = "filter", defaultValue = "ONGOING") StudyFilter filter,
+                                        @PageableDefault(size = 20) Pageable pageable) {
+
+        Page<StudySummaryRes> studies = studyService.getStudies(keyword, pageable, sort, filter);
+
+        return ResponseEntity.status(HttpStatus.OK).body(studies);
     }
 }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -37,4 +37,13 @@ public class StudyController implements StudyApi {
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
+
+    @PutMapping("/{studyId}")
+    public ResponseEntity<?> updateStudy(@PathVariable(value = "studyId") Long studyId,
+                                         @Valid @RequestBody StudyReq studyReq,
+                                         @AuthenticationPrincipal SecurityUserDetails userDetails) {
+        studyService.updateStudy(studyReq, studyId, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 수정되었습니다."));
+    }
 }

--- a/src/main/java/yuquiz/domain/study/dto/StudyFilter.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyFilter.java
@@ -1,0 +1,21 @@
+package yuquiz.domain.study.dto;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+import static yuquiz.domain.study.entity.QStudy.study;
+
+public enum StudyFilter {
+    ALL(null),
+    ONGOING(study.registerDuration.after(LocalDateTime.now())),
+    EXPIRED(study.registerDuration.before(LocalDateTime.now()));
+
+    @Getter
+    private final BooleanExpression filter;
+
+    StudyFilter(BooleanExpression filter) {
+        this.filter = filter;
+    }
+}

--- a/src/main/java/yuquiz/domain/study/dto/StudyReq.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyReq.java
@@ -5,6 +5,7 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import yuquiz.domain.study.entity.Study;
+import yuquiz.domain.study.entity.StudyState;
 import yuquiz.domain.user.entity.User;
 
 import java.time.LocalDateTime;
@@ -13,15 +14,20 @@ public record StudyReq(
         @NotBlank(message = "제목은 필수 입력입니다.")
         @Schema(description = "스터디 이름", example = "코딩 테스트 스터디")
         String name,
+
         @NotBlank(message = "설명은 필수 입력입니다.")
         @Schema(description = "스터디 설명", example = "코딩 테스트를 준비하기 위한 스터디입니다.")
         String description,
+
         @Schema(description = "스터디 신청 기간", example = "2024-10-06T12:00:00")
         LocalDateTime registerDuration,
+
         @NotNull(message = "최대 인원은 필수 입력입니다.")
         @Min(value = 2, message = "최소 인원은 2명입니다.")
         @Schema(description = "스터디 참가 최대 인원", example = "5")
-        Integer maxUser
+        Integer maxUser,
+
+        StudyState state
 
 ) {
     //todo : ChatRoom 개발 되면 추가하기

--- a/src/main/java/yuquiz/domain/study/dto/StudySortType.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudySortType.java
@@ -1,0 +1,20 @@
+package yuquiz.domain.study.dto;
+
+import com.querydsl.core.types.OrderSpecifier;
+import lombok.Getter;
+
+import static yuquiz.domain.study.entity.QStudy.study;
+
+public enum StudySortType {
+    CREATED_DESC(study.createdAt.desc()),
+    CREATED_ASC(study.createdAt.asc()),
+    REGISTER_DATE_DESC(study.registerDuration.desc()),
+    REGISTER_DATE_ASC(study.registerDuration.asc());
+
+    @Getter
+    private OrderSpecifier<?> order;
+
+    StudySortType(OrderSpecifier<?> order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/yuquiz/domain/study/dto/StudySummaryRes.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudySummaryRes.java
@@ -1,5 +1,6 @@
 package yuquiz.domain.study.dto;
 
+import yuquiz.domain.study.entity.Study;
 import yuquiz.domain.study.entity.StudyState;
 
 import java.time.LocalDateTime;
@@ -12,4 +13,13 @@ public record StudySummaryRes(
         LocalDateTime registerDuration,
         StudyState state
 ) {
+    public static StudySummaryRes fromEntity(Study study) {
+        return new StudySummaryRes(
+                study.getStudyName(),
+                study.getLeader().getNickname(),
+                study.getMaxUser(),
+                study.getCurrentUser(),
+                study.getRegisterDuration(),
+                study.getState());
+    }
 }

--- a/src/main/java/yuquiz/domain/study/dto/StudySummaryRes.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudySummaryRes.java
@@ -1,0 +1,15 @@
+package yuquiz.domain.study.dto;
+
+import yuquiz.domain.study.entity.StudyState;
+
+import java.time.LocalDateTime;
+
+public record StudySummaryRes(
+        String name,
+        String leaderName,
+        int maxUser,
+        int curUser,
+        LocalDateTime registerDuration,
+        StudyState state
+) {
+}

--- a/src/main/java/yuquiz/domain/study/entity/Study.java
+++ b/src/main/java/yuquiz/domain/study/entity/Study.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.common.entity.BaseTimeEntity;
 import yuquiz.domain.chatRoom.entity.ChatRoom;
+import yuquiz.domain.study.dto.StudyReq;
 import yuquiz.domain.studyUser.entity.StudyUser;
 import yuquiz.domain.user.entity.User;
 
@@ -59,5 +60,13 @@ public class Study extends BaseTimeEntity {
         this.registerDuration = registerDuration;
         this.leader = leader;
         this.state = StudyState.ACTIVE;
+    }
+
+    public void update(StudyReq studyReq) {
+        this.studyName = studyReq.name();
+        this.description = studyReq.description();
+        this.maxUser = studyReq.maxUser();
+        this.registerDuration = studyReq.registerDuration();
+        this.state = studyReq.state();
     }
 }

--- a/src/main/java/yuquiz/domain/study/entity/Study.java
+++ b/src/main/java/yuquiz/domain/study/entity/Study.java
@@ -51,6 +51,9 @@ public class Study extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private StudyState state;
 
+    @Column(name = "cur_user")
+    private Integer currentUser;
+
     @Builder
     public Study(String studyName, String description, ChatRoom chatRoom,Integer maxUser, LocalDateTime registerDuration, User leader) {
         this.studyName = studyName;
@@ -60,6 +63,7 @@ public class Study extends BaseTimeEntity {
         this.registerDuration = registerDuration;
         this.leader = leader;
         this.state = StudyState.ACTIVE;
+        this.currentUser = 1;
     }
 
     public void update(StudyReq studyReq) {

--- a/src/main/java/yuquiz/domain/study/repository/CustomStudyRepository.java
+++ b/src/main/java/yuquiz/domain/study/repository/CustomStudyRepository.java
@@ -1,0 +1,11 @@
+package yuquiz.domain.study.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import yuquiz.domain.study.dto.StudyFilter;
+import yuquiz.domain.study.dto.StudySortType;
+import yuquiz.domain.study.entity.Study;
+
+public interface CustomStudyRepository {
+    Page<Study> getStudies(String keyword, Pageable pageable, StudySortType sort, StudyFilter filter);
+}

--- a/src/main/java/yuquiz/domain/study/repository/CustomStudyRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/study/repository/CustomStudyRepositoryImpl.java
@@ -1,0 +1,57 @@
+package yuquiz.domain.study.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import yuquiz.domain.study.dto.StudyFilter;
+import yuquiz.domain.study.dto.StudySortType;
+import yuquiz.domain.study.entity.Study;
+
+import java.util.List;
+
+import static yuquiz.domain.study.entity.QStudy.study;
+
+public class CustomStudyRepositoryImpl implements CustomStudyRepository{
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CustomStudyRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Page<Study> getStudies(String keyword, Pageable pageable, StudySortType sort, StudyFilter filter) {
+        List<Study> studies = jpaQueryFactory
+                .select(study)
+                .from(study)
+                .where(wordContain(keyword), filter.getFilter())
+                .orderBy(sort.getOrder())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(study.count())
+                .from(study)
+                .where(wordContain(keyword))
+                .fetchOne();
+
+        return new PageImpl<>(studies, pageable, total);
+    }
+
+    private BooleanExpression wordContain(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return null;
+        }
+
+        return Expressions.booleanTemplate(
+                "function('match', {0}, {1}, {2}) > 0",
+                study.studyName,
+                study.description,
+                keyword
+        );
+    }
+}

--- a/src/main/java/yuquiz/domain/study/repository/StudyRepository.java
+++ b/src/main/java/yuquiz/domain/study/repository/StudyRepository.java
@@ -6,7 +6,7 @@ import yuquiz.domain.study.entity.Study;
 
 import java.util.Optional;
 
-public interface StudyRepository extends JpaRepository<Study, Long> {
+public interface StudyRepository extends JpaRepository<Study, Long>, CustomStudyRepository{
     @Query("SELECT s.leader.id FROM Study s WHERE s.id = :studyId")
     Optional<Long> findLeaderById(Long studyId);
 }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -49,6 +49,18 @@ public class StudyService {
         studyRepository.deleteById(studyId);
     }
 
+    @Transactional
+    public void updateStudy(StudyReq studyReq, Long studyId, Long userId) {
+        if (!validateLeader(studyId, userId)) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
+
+        study.update(studyReq);
+    }
+
     private boolean validateLeader(Long studyId, Long userId) {
         return studyRepository.findLeaderById(studyId)
                 .map(leaderId -> leaderId.equals(userId))

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -1,10 +1,15 @@
 package yuquiz.domain.study.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
+import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
+import yuquiz.domain.study.dto.StudySortType;
+import yuquiz.domain.study.dto.StudySummaryRes;
 import yuquiz.domain.study.entity.Study;
 import yuquiz.domain.study.exception.StudyExceptionCode;
 import yuquiz.domain.study.repository.StudyRepository;
@@ -59,6 +64,14 @@ public class StudyService {
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
 
         study.update(studyReq);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<StudySummaryRes> getStudies(String keyword, Pageable pageable, StudySortType sort, StudyFilter filter) {
+
+        Page<Study> studies = studyRepository.getStudies(keyword, pageable, sort, filter);
+
+        return studies.map(StudySummaryRes::fromEntity);
     }
 
     private boolean validateLeader(Long studyId, Long userId) {


### PR DESCRIPTION
## 개요
스터디 수정, 목록 조회 기능을 구현하였습니다.

## 구현사항
* 스터디 수정
* 스터디 목록 조회(검색) 기능 구현

## 기타
스터디 검색에 filter를 추가하여 현재 모집 중(ONGOING), 모집 종료(EXPIRED), 전체(ALL) 을 선택하여 조회할 수 있게 하였습니다.
나머지는 다른 기능들과 동일합니다.

## 테스트
스터디 수정 성공
<img width="681" alt="image" src="https://github.com/user-attachments/assets/5e1325f2-7b14-451d-9354-335ac2e7a533">

스터디 수정 실패(권한 없음)
<img width="621" alt="image" src="https://github.com/user-attachments/assets/2c90af5a-5098-4ca6-aeef-aabfba1a46f0">

스터디 수정 실패(유효성 검증)
스터디 생성과 동일합니다.

스터디 목록 조회 (신청 기간이 지난 것들)
현재 시간 (2024-10-13)을 기준으로 지난 스터디만 보여줌
<img width="631" alt="image" src="https://github.com/user-attachments/assets/0623a65f-085d-4a1d-bfe1-13142041c866">

