### PR TITLE
feat: 스터디 조회, 가입 관련 기능 구현

### DIFF
--- a/src/main/java/yuquiz/domain/notification/dto/NotificationRes.java
+++ b/src/main/java/yuquiz/domain/notification/dto/NotificationRes.java
@@ -11,6 +11,7 @@ import yuquiz.domain.user.entity.User;
 import java.time.LocalDateTime;
 
 public record NotificationRes(
+        Long id,
 
         String title,
 
@@ -24,6 +25,7 @@ public record NotificationRes(
 ) {
     public static NotificationRes fromEntity (Notification notification) {
         return new NotificationRes(
+                notification.getId(),
                 notification.getTitle(),
                 notification.getMessage(),
                 notification.isChecked(),

--- a/src/main/java/yuquiz/domain/notification/dto/NotificationRes.java
+++ b/src/main/java/yuquiz/domain/notification/dto/NotificationRes.java
@@ -1,12 +1,6 @@
 package yuquiz.domain.notification.dto;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.validation.constraints.NotNull;
 import yuquiz.domain.notification.entity.Notification;
-import yuquiz.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -86,4 +86,14 @@ public class StudyController implements StudyApi {
 
         return ResponseEntity.status(HttpStatus.OK).body(studyService.getRegisterRequests(studyId, userDetails.getId()));
     }
+
+    @PostMapping("/{studyId}/accept")
+    public ResponseEntity<?> acceptRequest(@PathVariable(value = "studyId") Long studyId,
+                                           @RequestParam(value = "id") Long pendingUserId,
+                                           @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        studyService.acceptRequest(studyId, pendingUserId, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 승인되었습니다."));
+    }
 }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -79,4 +79,11 @@ public class StudyController implements StudyApi {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 신청되었습니다."));
     }
+
+    @GetMapping("/{studyId}/request")
+    public ResponseEntity<?> getRequests(@PathVariable(value = "studyId") Long studyId,
+                                         @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(studyService.getRegisterRequests(studyId, userDetails.getId()));
+    }
 }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -70,4 +70,13 @@ public class StudyController implements StudyApi {
 
         return ResponseEntity.status(HttpStatus.OK).body(studyService.getStudy(studyId, userDetails.getId()));
     }
+
+    @PostMapping("/{studyId}/request")
+    public ResponseEntity<?> requestRegister(@PathVariable(value = "studyId") Long studyId,
+                                             @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        studyService.requestRegister(studyId, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 신청되었습니다."));
+    }
 }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -63,4 +63,11 @@ public class StudyController implements StudyApi {
 
         return ResponseEntity.status(HttpStatus.OK).body(studies);
     }
+
+    @GetMapping("/{studyId}")
+    public ResponseEntity<?> getStudy(@PathVariable(value = "studyId") Long studyId,
+                                      @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(studyService.getStudy(studyId, userDetails.getId()));
+    }
 }

--- a/src/main/java/yuquiz/domain/study/dto/StudyRequestRes.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyRequestRes.java
@@ -1,0 +1,20 @@
+package yuquiz.domain.study.dto;
+
+import yuquiz.domain.studyUser.entity.StudyUser;
+
+import java.time.LocalDateTime;
+
+public record StudyRequestRes(
+        Long userId,
+        String name,
+        LocalDateTime requestAt
+
+) {
+    public static StudyRequestRes fromEntity(StudyUser studyUser) {
+        return new StudyRequestRes(
+                studyUser.getUser().getId(),
+                studyUser.getUser().getNickname(),
+                studyUser.getJoinedAt()
+        );
+    }
+}

--- a/src/main/java/yuquiz/domain/study/dto/StudyRes.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyRes.java
@@ -1,0 +1,33 @@
+package yuquiz.domain.study.dto;
+
+import yuquiz.domain.study.entity.Study;
+import yuquiz.domain.study.entity.StudyState;
+import yuquiz.domain.studyUser.entity.StudyRole;
+
+import java.time.LocalDateTime;
+
+public record StudyRes(
+        Long id,
+        String Name,
+        String description,
+        LocalDateTime registerDuration,
+        Integer maxUser,
+        Integer curUser,
+        StudyState state,
+        boolean isMember,
+        StudyRole role
+) {
+    public static StudyRes fromEntity(Study study, boolean isMember, StudyRole role) {
+        return new StudyRes(
+                study.getId(),
+                study.getStudyName(),
+                study.getDescription(),
+                study.getRegisterDuration(),
+                study.getMaxUser(),
+                study.getCurrentUser(),
+                study.getState(),
+                isMember,
+                role
+        );
+    }
+}

--- a/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
+++ b/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
@@ -7,7 +7,8 @@ import yuquiz.common.exception.exceptionCode.ExceptionCode;
 public enum StudyExceptionCode implements ExceptionCode {
 
     INVALID_ID(404, "존재하지 않는 스터디입니다."),
-    UNAUTHORIZED_ACTION(403, "권한이 없습니다.");
+    UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
+    ALREADY_REGISTERED(409, "이미 가입된 스터디입니다.");
 
 
     private final int status;

--- a/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
+++ b/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
@@ -8,7 +8,8 @@ public enum StudyExceptionCode implements ExceptionCode {
 
     INVALID_ID(404, "존재하지 않는 스터디입니다."),
     UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
-    ALREADY_REGISTERED(409, "이미 가입된 스터디입니다.");
+    ALREADY_REGISTERED(409, "이미 가입되었습니다."),
+    REQUEST_NOT_EXIST(404, "존재하지 않는 가입 신청입니다.");
 
 
     private final int status;

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
 import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
+import yuquiz.domain.study.dto.StudyRes;
 import yuquiz.domain.study.dto.StudySortType;
 import yuquiz.domain.study.dto.StudySummaryRes;
 import yuquiz.domain.study.entity.Study;
@@ -72,6 +73,17 @@ public class StudyService {
         Page<Study> studies = studyRepository.getStudies(keyword, pageable, sort, filter);
 
         return studies.map(StudySummaryRes::fromEntity);
+    }
+
+    @Transactional(readOnly = true)
+    public StudyRes getStudy(Long studyId, Long userId) {
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
+
+        return studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, userId)
+                .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole()))
+                .orElseGet(() -> StudyRes.fromEntity(study, false, null));
     }
 
     private boolean validateLeader(Long studyId, Long userId) {

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -85,7 +85,7 @@ public class StudyService {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
 
-        return studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, userId)
+        return studyUserRepository.findStudyUserByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)
                 .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole()))
                 .orElseGet(() -> StudyRes.fromEntity(study, false, null));
     }
@@ -130,12 +130,8 @@ public class StudyService {
             throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
         }
 
-        StudyUser studyUser = studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, pendingUserId)
+        StudyUser studyUser = studyUserRepository.findStudyUserByStudy_IdAndUser_IdAndState(studyId, pendingUserId, UserState.PENDING)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.REQUEST_NOT_EXIST));
-
-        if (studyUser.getState().equals(UserState.REGISTERED)) {
-            throw new CustomException(StudyExceptionCode.ALREADY_REGISTERED);
-        }
 
         studyUser.accept();
     }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -24,7 +24,6 @@ import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -125,6 +125,22 @@ public class StudyService {
         return studyUsers.stream().map(StudyRequestRes::fromEntity).toList();
     }
 
+    @Transactional
+    public void acceptRequest(Long studyId, Long pendingUserId, Long userId) {
+        if (!validateLeader(studyId, userId)) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        StudyUser studyUser = studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, pendingUserId)
+                .orElseThrow(() -> new CustomException(StudyExceptionCode.REQUEST_NOT_EXIST));
+
+        if (studyUser.getState().equals(UserState.REGISTERED)) {
+            throw new CustomException(StudyExceptionCode.ALREADY_REGISTERED);
+        }
+
+        studyUser.accept();
+    }
+
     private boolean validateLeader(Long studyId, Long userId) {
         return studyRepository.findLeaderById(studyId)
                 .map(leaderId -> leaderId.equals(userId))

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -8,6 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
 import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
+import yuquiz.domain.study.dto.StudyRequestRes;
 import yuquiz.domain.study.dto.StudyRes;
 import yuquiz.domain.study.dto.StudySortType;
 import yuquiz.domain.study.dto.StudySummaryRes;
@@ -21,6 +22,9 @@ import yuquiz.domain.studyUser.repository.StudyUserRepository;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
+
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -108,6 +112,17 @@ public class StudyService {
                 .build();
 
         studyUserRepository.save(studyUser);
+    }
+
+    @Transactional(readOnly = true)
+    public List<StudyRequestRes> getRegisterRequests(Long studyId, Long userId) {
+        if (!validateLeader(studyId, userId)) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        List<StudyUser> studyUsers = studyUserRepository.findByStudyIdAndState(studyId, UserState.PENDING);
+
+        return studyUsers.stream().map(StudyRequestRes::fromEntity).toList();
     }
 
     private boolean validateLeader(Long studyId, Long userId) {

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -16,6 +16,7 @@ import yuquiz.domain.study.exception.StudyExceptionCode;
 import yuquiz.domain.study.repository.StudyRepository;
 import yuquiz.domain.studyUser.entity.StudyRole;
 import yuquiz.domain.studyUser.entity.StudyUser;
+import yuquiz.domain.studyUser.entity.UserState;
 import yuquiz.domain.studyUser.repository.StudyUserRepository;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
@@ -84,6 +85,29 @@ public class StudyService {
         return studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, userId)
                 .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole()))
                 .orElseGet(() -> StudyRes.fromEntity(study, false, null));
+    }
+
+    @Transactional
+    public void requestRegister(Long studyId, Long userId) {
+
+        if (studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+            throw new CustomException(StudyExceptionCode.ALREADY_REGISTERED);
+        }
+
+        Study study = studyRepository.findById(studyId)
+                .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
+
+        StudyUser studyUser = StudyUser.builder()
+                .user(user)
+                .study(study)
+                .state(UserState.PENDING)
+                .role(StudyRole.USER)
+                .build();
+
+        studyUserRepository.save(studyUser);
     }
 
     private boolean validateLeader(Long studyId, Long userId) {

--- a/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
+++ b/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
@@ -44,6 +44,7 @@ public class StudyUser {
 
 
     @Enumerated(EnumType.STRING)
+    @Column(name = "state", length = 50)
     private UserState state;
 
     @Builder
@@ -53,5 +54,10 @@ public class StudyUser {
         this.chatRoom = chatRoom;
         this.role = role;
         this.state = state;
+    }
+
+    public void accept() {
+        this.joinedAt = LocalDateTime.now();
+        this.state = UserState.REGISTERED;
     }
 }

--- a/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
+++ b/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
@@ -42,11 +42,16 @@ public class StudyUser {
     @JoinColumn(name = "chat_room_id")
     private ChatRoom chatRoom;
 
+
+    @Enumerated(EnumType.STRING)
+    private UserState state;
+
     @Builder
-    public StudyUser(User user, Study study, ChatRoom chatRoom, StudyRole role) {
+    public StudyUser(User user, Study study, ChatRoom chatRoom, StudyRole role, UserState state) {
         this.user = user;
         this.study = study;
         this.chatRoom = chatRoom;
         this.role = role;
+        this.state = state;
     }
 }

--- a/src/main/java/yuquiz/domain/studyUser/entity/UserState.java
+++ b/src/main/java/yuquiz/domain/studyUser/entity/UserState.java
@@ -1,0 +1,5 @@
+package yuquiz.domain.studyUser.entity;
+
+public enum UserState {
+    PENDING, REGISTERED
+}

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -10,7 +10,7 @@ import java.util.Optional;
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
     boolean existsByStudy_IdAndUser_Id(Long studyId, Long userId);
 
-    Optional<StudyUser> findStudyUserByStudy_IdAndUser_Id(Long studyId, Long userId);
+    Optional<StudyUser> findStudyUserByStudy_IdAndUser_IdAndState(Long studyId, Long userId, UserState state);
 
     List<StudyUser> findByStudyIdAndState(Long studyId, UserState state);
 }

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -3,6 +3,10 @@ package yuquiz.domain.studyUser.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.studyUser.entity.StudyUser;
 
+import java.util.Optional;
+
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
     boolean existsByStudy_IdAndUser_Id(Long studyId, Long userId);
+
+    Optional<StudyUser> findStudyUserByStudy_IdAndUser_Id(Long studyId, Long userId);
 }

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -2,11 +2,15 @@ package yuquiz.domain.studyUser.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.studyUser.entity.StudyUser;
+import yuquiz.domain.studyUser.entity.UserState;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
     boolean existsByStudy_IdAndUser_Id(Long studyId, Long userId);
 
     Optional<StudyUser> findStudyUserByStudy_IdAndUser_Id(Long studyId, Long userId);
+
+    List<StudyUser> findByStudyIdAndState(Long studyId, UserState state);
 }


### PR DESCRIPTION
## 개요
스터디 상세 조회, 가입 관련 기능을 구현하였습니다.

## 구현사항
* 스터디 상세 조회
* 스터디 가입 신청
* 스터디 가입 신청 목록 조회 
* 스터디 가입 신청 수락

## 기타
스터디 조회 시 조회한 사용자가 해당 스터디의 스터디원인지에 대한 정보인 isMember, 해당 스터디에서의 역할인 role을 추가하였습니다.
프론트에서 isMember를 통해 스터디원이 아니라면 스터디 신청을 할 수 있고, role을 통해 스터디에서의 각 역할에 맞게 동작을 제어할 수 있게하였습니다.



## 테스트
스터디 조회
<img width="635" alt="image" src="https://github.com/user-attachments/assets/2d7c23ec-4777-4119-8df3-0ce60eb78b7b">


스터디 가입 신청
<img width="629" alt="image" src="https://github.com/user-attachments/assets/310ce5c5-e11c-4984-ba2b-b16a4178a125">

스터디 가입 신청 실패 (이미 가입된 스터디)
<img width="628" alt="image" src="https://github.com/user-attachments/assets/b53d0409-87fd-4b68-813e-96311a831620">

스터디 가입 신청 목록
<img width="635" alt="image" src="https://github.com/user-attachments/assets/3030e120-aeef-46f0-bbf4-84aadff5104b">

스터디 가입 신청 수락
<img width="655" alt="image" src="https://github.com/user-attachments/assets/e8ca2523-134b-4d6f-8c78-b9ba245893ea">

