### PR TITLE
feat: 문제집 정보 수정 기능 추가, 문제집에 퀴즈 추가 및 삭제 기능 추가

### DIFF
--- a/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
+++ b/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
@@ -1,0 +1,56 @@
+package yuquiz.domain.quizSeries.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import yuquiz.security.auth.SecurityUserDetails;
+
+@Tag(name = "[문제집내 퀴즈 API]", description = "문제집내 퀴즈 관련 API")
+public interface QuizSeriesApi {
+    @Operation(summary = "문제집에 퀴즈 추가", description = "문제집에 퀴즈를 추가하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "퀴즈 추가 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "response": "문제집에 문제 추가 성공"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> addQuizToSeries(@PathVariable(value = "seriesId") Long seriesId,
+                                      @PathVariable(value = "quizId") Long quizId,
+                                      @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "문제집에서 퀴즈 삭제", description = "문제집에서 퀴즈를 삭제하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "문제집에서 퀴즈 삭제 성공"),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteQuizFromSeries(@PathVariable(value = "seriesId") Long seriesId,
+                                           @PathVariable(value = "quizId") Long quizId,
+                                           @AuthenticationPrincipal SecurityUserDetails userDetails);
+}

--- a/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
+++ b/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
@@ -31,6 +31,15 @@ public interface QuizSeriesApi {
                                         "message": "권한이 없습니다."
                                     }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "중복된 퀴즈",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "이미 문제집에 추가된 문제입니다."
+                                    }
+                                    """)
                     }))
     })
     ResponseEntity<?> addQuizToSeries(@PathVariable(value = "seriesId") Long seriesId,

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -6,16 +6,18 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.quizSeries.api.QuizSeriesApi;
 import yuquiz.domain.quizSeries.service.QuizSeriesService;
 import yuquiz.security.auth.SecurityUserDetails;
 
 @RestController
 @RequestMapping("/api/v1/series")
 @RequiredArgsConstructor
-public class QuizSeriesController {
+public class QuizSeriesController implements QuizSeriesApi {
 
     private final QuizSeriesService quizSeriesService;
 
+    @Override
     @PostMapping("/{seriesId}/{quizId}")
     public ResponseEntity<?> addQuizToSeries(@PathVariable(value = "seriesId") Long seriesId,
                                              @PathVariable(value = "quizId") Long quizId,
@@ -26,7 +28,7 @@ public class QuizSeriesController {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("문제집에 문제 추가 성공"));
     }
 
-
+    @Override
     @DeleteMapping("/{seriesId}/{quizId}")
     public ResponseEntity<?> deleteQuizFromSeries(@PathVariable(value = "seriesId") Long seriesId,
                                                   @PathVariable(value = "quizId") Long quizId,

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.quizSeries.service.QuizSeriesService;
 import yuquiz.security.auth.SecurityUserDetails;
@@ -27,5 +24,16 @@ public class QuizSeriesController {
         quizSeriesService.addQuiz(seriesId, quizId, userDetails.getId());
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("문제집에 문제 추가 성공"));
+    }
+
+
+    @DeleteMapping("/{seriesId}/{quizId}")
+    public ResponseEntity<?> deleteQuizFromSeries(@PathVariable(value = "seriesId") Long seriesId,
+                                                  @PathVariable(value = "quizId") Long quizId,
+                                                  @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        quizSeriesService.deleteQuiz(seriesId, quizId, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -1,0 +1,31 @@
+package yuquiz.domain.quizSeries.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.quizSeries.service.QuizSeriesService;
+import yuquiz.security.auth.SecurityUserDetails;
+
+@RestController
+@RequestMapping("/api/v1/series")
+@RequiredArgsConstructor
+public class QuizSeriesController {
+
+    private final QuizSeriesService quizSeriesService;
+
+    @PostMapping("/{seriesId}/{quizId}")
+    public ResponseEntity<?> addQuizToSeries(@PathVariable(value = "seriesId") Long seriesId,
+                                             @PathVariable(value = "quizId") Long quizId,
+                                             @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        quizSeriesService.addQuiz(seriesId, quizId, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("문제집에 문제 추가 성공"));
+    }
+}

--- a/src/main/java/yuquiz/domain/quizSeries/entity/QuizSeries.java
+++ b/src/main/java/yuquiz/domain/quizSeries/entity/QuizSeries.java
@@ -11,6 +11,14 @@ import yuquiz.domain.series.entity.Series;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "QuizSeries",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "quizSeries",
+                        columnNames = {"series_id", "quiz_id"}
+                )
+        }
+)
 public class QuizSeries {
 
     @Id

--- a/src/main/java/yuquiz/domain/quizSeries/exception/QuizSeriesExceptionCode.java
+++ b/src/main/java/yuquiz/domain/quizSeries/exception/QuizSeriesExceptionCode.java
@@ -1,0 +1,23 @@
+package yuquiz.domain.quizSeries.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum QuizSeriesExceptionCode implements ExceptionCode {
+    INVALID_ID(404, "문제집에 추가되지 않은 문제입니다."),
+    UNAUTHORIZED_ACTION(403, "권한이 없습니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/yuquiz/domain/quizSeries/exception/QuizSeriesExceptionCode.java
+++ b/src/main/java/yuquiz/domain/quizSeries/exception/QuizSeriesExceptionCode.java
@@ -6,7 +6,8 @@ import yuquiz.common.exception.exceptionCode.ExceptionCode;
 @AllArgsConstructor
 public enum QuizSeriesExceptionCode implements ExceptionCode {
     INVALID_ID(404, "문제집에 추가되지 않은 문제입니다."),
-    UNAUTHORIZED_ACTION(403, "권한이 없습니다.");
+    UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
+    ALREADY_ADDED(404, "이미 문제집에 추가된 문제입니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
@@ -4,4 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.quizSeries.entity.QuizSeries;
 
 public interface QuizSeriesRepository extends JpaRepository<QuizSeries, Long> {
+    void deleteBySeries_IdAndQuiz_Id(Long seriesId, Long quizId);
 }

--- a/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
@@ -5,4 +5,6 @@ import yuquiz.domain.quizSeries.entity.QuizSeries;
 
 public interface QuizSeriesRepository extends JpaRepository<QuizSeries, Long> {
     void deleteBySeries_IdAndQuiz_Id(Long seriesId, Long quizId);
+
+    boolean existsBySeries_IdAndQuiz_Id(Long seriesId, Long quizId);
 }

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -29,6 +29,10 @@ public class QuizSeriesService {
             throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);
         }
 
+        if (quizSeriesRepository.existsBySeries_IdAndQuiz_Id(seriesId, quizId)) {
+            throw new CustomException(QuizSeriesExceptionCode.ALREADY_ADDED);
+        }
+
         Series series = seriesRepository.findById(seriesId)
                 .orElseThrow(() -> new CustomException(SeriesExceptionCode.INVALID_ID));
 

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -1,0 +1,49 @@
+package yuquiz.domain.quizSeries.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yuquiz.common.exception.CustomException;
+import yuquiz.domain.quiz.entity.Quiz;
+import yuquiz.domain.quiz.exception.QuizExceptionCode;
+import yuquiz.domain.quiz.repository.QuizRepository;
+import yuquiz.domain.quizSeries.entity.QuizSeries;
+import yuquiz.domain.quizSeries.exception.QuizSeriesExceptionCode;
+import yuquiz.domain.quizSeries.repository.QuizSeriesRepository;
+import yuquiz.domain.series.entity.Series;
+import yuquiz.domain.series.exception.SeriesExceptionCode;
+import yuquiz.domain.series.repository.SeriesRepository;
+
+@Service
+@RequiredArgsConstructor
+public class QuizSeriesService {
+
+    private final QuizSeriesRepository quizSeriesRepository;
+    private final QuizRepository quizRepository;
+    private final SeriesRepository seriesRepository;
+
+    public void addQuiz(Long seriesId, Long quizId, Long userId) {
+
+        if (!validateCreator(seriesId, userId)) {
+            throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        Series series = seriesRepository.findById(seriesId)
+                .orElseThrow(() -> new CustomException(SeriesExceptionCode.INVALID_ID));
+
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new CustomException(QuizExceptionCode.INVALID_ID));
+
+        QuizSeries quizSeries = QuizSeries.builder()
+                .series(series)
+                .quiz(quiz)
+                .build();
+
+        quizSeriesRepository.save(quizSeries);
+    }
+
+    private boolean validateCreator(Long seriesId, Long userId) {
+        return seriesRepository.findCreatorIdById(seriesId)
+                .map(creatorId -> creatorId.equals(userId))
+                .orElse(false);
+    }
+}

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -2,6 +2,7 @@ package yuquiz.domain.quizSeries.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
 import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quiz.exception.QuizExceptionCode;
@@ -21,6 +22,7 @@ public class QuizSeriesService {
     private final QuizRepository quizRepository;
     private final SeriesRepository seriesRepository;
 
+    @Transactional
     public void addQuiz(Long seriesId, Long quizId, Long userId) {
 
         if (!validateCreator(seriesId, userId)) {
@@ -39,6 +41,16 @@ public class QuizSeriesService {
                 .build();
 
         quizSeriesRepository.save(quizSeries);
+    }
+
+    @Transactional
+    public void deleteQuiz(Long seriesId, Long quizId, Long userId) {
+
+        if (!validateCreator(seriesId, userId)) {
+            throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        quizSeriesRepository.deleteBySeries_IdAndQuiz_Id(seriesId, quizId);
     }
 
     private boolean validateCreator(Long seriesId, Long userId) {

--- a/src/main/java/yuquiz/domain/series/api/SeriesApi.java
+++ b/src/main/java/yuquiz/domain/series/api/SeriesApi.java
@@ -91,6 +91,37 @@ public interface SeriesApi {
     })
     ResponseEntity<?> deleteSeriesById(@PathVariable(value = "seriesId") Long seriesId, @AuthenticationPrincipal SecurityUserDetails userDetails);
 
+    @Operation(summary = "문제집 상세정보 수정", description = "문제집 상세정보를 수정하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "수정 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "response": "문제집 수정 성공"
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "400", description = "유효성 검사 실패",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "name": "문제집 이름은 필수 입력입니다.",
+                                        "studyId": "스터디ID는 1 이상이어야 합니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> updateSeriesById(@PathVariable(value = "seriesId") Long seriesId, @RequestBody @Valid SeriesReq seriesReq, @AuthenticationPrincipal SecurityUserDetails userDetails);
+
     @Operation(summary = "문제집 목록 조회", description = "문제집 목록을 조회하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공",

--- a/src/main/java/yuquiz/domain/series/controller/SeriesController.java
+++ b/src/main/java/yuquiz/domain/series/controller/SeriesController.java
@@ -30,7 +30,7 @@ public class SeriesController implements SeriesApi {
 
         seriesService.createSeries(seriesReq, userDetails.getId());
 
-        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("문제집이 생성되었습니다."));
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("문제집 생성 성공"));
     }
 
     @Override
@@ -49,6 +49,15 @@ public class SeriesController implements SeriesApi {
         seriesService.deleteSeriesById(seriesId, userDetails.getId());
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Override
+    @PutMapping("/{seriesId}")
+    public ResponseEntity<?> updateSeriesById(@PathVariable(value = "seriesId") Long seriesId, @RequestBody @Valid SeriesReq seriesReq, @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        seriesService.updateSeriesById(seriesId, seriesReq, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("문제집 수정 성공"));
     }
 
     @Override

--- a/src/main/java/yuquiz/domain/series/entity/Series.java
+++ b/src/main/java/yuquiz/domain/series/entity/Series.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.common.entity.BaseTimeEntity;
 import yuquiz.domain.quizSeries.entity.QuizSeries;
+import yuquiz.domain.series.dto.SeriesReq;
 import yuquiz.domain.study.entity.Study;
 import yuquiz.domain.user.entity.User;
 
@@ -42,6 +43,11 @@ public class Series extends BaseTimeEntity {
     public Series(String name, User creator, Study study) {
         this.name = name;
         this.creator = creator;
+        this.study = study;
+    }
+
+    public void update(SeriesReq seriesReq, Study study) {
+        this.name = seriesReq.name();
         this.study = study;
     }
 }


### PR DESCRIPTION
## 개요

문제집의 정보를 수정할 수 있도록 하였습니다.
문제집에 퀴즈를 추가하고 삭제하는 기능을 추가하였습니다.

## 구현사항

- 문제집 정보 수정 기능
- 문제집에 퀴즈 추가 기능
- 문제집에서 퀴즈 삭제 기능
- Swagger 작성

## 기타

문제집에 퀴즈를 추가하는 과정에서 문제집을 검사하는 과정이 있습니다.
비즈니스 로직에서 exist를 통해 검사하도록 하였습니다.
혹여나 해당 로직이 동작하지 않는 경우를 대비해 db에 constraint를 이용해 제약조건을 주었습니다.

## 테스트

1. 문제집 정보 수정 (성공)

<img width="836" alt="image" src="https://github.com/user-attachments/assets/4d85e8fa-c8c3-4f04-ba19-6045fb2fc270">

2. 문제집 정보 수정 (실패 - 권한없음)

<img width="841" alt="image" src="https://github.com/user-attachments/assets/9e3afc0a-f585-46d5-9883-095a6b5c718d">

3. 문제집 정보 수정 (실패 - 유효성 검사 실패, 문제집 이름 누락)

<img width="835" alt="image" src="https://github.com/user-attachments/assets/503e990b-9601-46b1-a9fd-b2f1d79a2d18">

4. 문제집 정보 수정 (실패 - 유효성 검사 실패, 스터디 id 유효성 검사 실패)

<img width="833" alt="image" src="https://github.com/user-attachments/assets/f69d71cf-a9e6-40c5-9d3c-e9d99a8c5896">

5. 문제집에 문제 추가 (성공)

<img width="771" alt="image" src="https://github.com/user-attachments/assets/b9ec5142-4993-4042-9744-b9959e73ddcd">

6. 문제집에 문제 추가 (실패 - 권한없음)

<img width="766" alt="image" src="https://github.com/user-attachments/assets/2ccee279-5908-408f-ae28-782795617702">

7. 문제집에 문제 추가 (실패 - 중복된 문제)

<img width="769" alt="image" src="https://github.com/user-attachments/assets/dcbdbb43-9cc3-4649-8cd9-9fb696a05bb6">

8. 문제집에서 문제 삭제 (성공)

<img width="767" alt="image" src="https://github.com/user-attachments/assets/e41a8397-d59b-40b2-8ffd-ea02e70bc5cb">

9. 문제집에서 문제 삭제 (실패 - 권한없음)

<img width="769" alt="image" src="https://github.com/user-attachments/assets/686c69af-f93e-44f0-ba18-e9fdf3dfb234">