### PR TITLE
feat: 채팅 메시지 권한 처리

### DIFF
--- a/src/main/java/yuquiz/common/utils/redis/RedisProperties.java
+++ b/src/main/java/yuquiz/common/utils/redis/RedisProperties.java
@@ -6,6 +6,9 @@ public interface RedisProperties {
     String BLACKLIST_KEY_PREFIX = "blackList::";
     String CODE_KEY_PREFIX = "code::";
     String PASS_KEY_PREFIX = "pass::";
+    String CHAT_PREFIX = "chat::";
+    String MEMBER_PREFIX = "::member::";
     long CODE_EXPIRATION_TIME = 3*60;
     long PASS_EXPIRATION_TIME = 5*60;
+    long CHAT_EXPIRATION_TIME = 6*60*60;
 }

--- a/src/main/java/yuquiz/config/WebSocketConfig.java
+++ b/src/main/java/yuquiz/config/WebSocketConfig.java
@@ -8,14 +8,14 @@ import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBr
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 import yuquiz.domain.chatRoom.websocket.error.StompErrorHandler;
-import yuquiz.domain.chatRoom.websocket.interceptor.JwtChannelInterceptor;
+import yuquiz.domain.chatRoom.websocket.interceptor.SocketChannelInterceptor;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
-    private final JwtChannelInterceptor jwtChannelInterceptor;
+    private final SocketChannelInterceptor socketChannelInterceptor;
     private final StompErrorHandler stompErrorHandler;
 
     @Override
@@ -33,7 +33,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-        registration.interceptors(jwtChannelInterceptor);
+        registration.interceptors(socketChannelInterceptor);
     }
 
 }

--- a/src/main/java/yuquiz/domain/chatRoom/controller/MessageController.java
+++ b/src/main/java/yuquiz/domain/chatRoom/controller/MessageController.java
@@ -5,7 +5,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.ChannelTopic;
 import org.springframework.messaging.handler.annotation.MessageMapping;
-import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.web.bind.annotation.RestController;
 import yuquiz.domain.chatRoom.dto.MessageReq;
 
@@ -16,17 +15,10 @@ public class MessageController {
 
     private final RedisTemplate redisTemplate;
     private final ChannelTopic channelTopic;
-//    private final ChatUserService chatUserService;
 
     /* 방에 메시지 전송 */
-    @MessageMapping("/message/{roomId}")    // 클라이언트가 서버로 보내는 메시지를 처리할 경로
-    public MessageReq sendMessage(MessageReq messageReq, StompHeaderAccessor accessor) {
-
-        Long userId = (Long) accessor.getSessionAttributes().get("userId");
-
-//        if (chatUserService.isChatMember(userId, Long.valueOf(messageReq.getRoomId()))) {
-//            log.error("권한 없음");
-//        }
+    @MessageMapping("/message/{roomId}")
+    public MessageReq sendMessage(MessageReq messageReq) {
 
         redisTemplate.convertAndSend(channelTopic.getTopic(), messageReq);
         return messageReq;
@@ -34,13 +26,7 @@ public class MessageController {
 
     /* 채팅방에 유저가 입장했을 때의 메시지 처리 */
     @MessageMapping("/user/{roomId}")
-    public MessageReq addUser(MessageReq messageReq, StompHeaderAccessor accessor) {
-
-        Long userId = (Long) accessor.getSessionAttributes().get("userId");
-
-//        if (chatUserService.isChatMember(userId, Long.valueOf(messageReq.getRoomId()))) {
-//            log.error("권한 없음");
-//        }
+    public MessageReq addUser(MessageReq messageReq) {
 
         redisTemplate.convertAndSend(channelTopic.getTopic(), messageReq);
         return messageReq;

--- a/src/main/java/yuquiz/domain/chatRoom/entity/ChatRoom.java
+++ b/src/main/java/yuquiz/domain/chatRoom/entity/ChatRoom.java
@@ -7,6 +7,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import yuquiz.domain.study.entity.Study;
@@ -17,6 +19,8 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
 @Entity
 public class ChatRoom {
 

--- a/src/main/java/yuquiz/domain/chatRoom/exception/ChatRoomExceptionCode.java
+++ b/src/main/java/yuquiz/domain/chatRoom/exception/ChatRoomExceptionCode.java
@@ -1,16 +1,14 @@
-package yuquiz.domain.study.exception;
+package yuquiz.domain.chatRoom.exception;
 
 import lombok.AllArgsConstructor;
 import yuquiz.common.exception.exceptionCode.ExceptionCode;
 
 @AllArgsConstructor
-public enum StudyExceptionCode implements ExceptionCode {
+public enum ChatRoomExceptionCode implements ExceptionCode {
 
-    INVALID_ID(404, "존재하지 않는 스터디입니다."),
-    UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
-    ALREADY_REGISTERED(409, "이미 가입되었습니다."),
-    REQUEST_NOT_EXIST(404, "존재하지 않는 가입 신청입니다.");
-
+    UNAUTHORIZED_ACTION(403, "채팅방 입장 권한이 없습니다."),
+    INVALID_ID(404, "존재하지 않는 채팅방입니다."),
+    CANNOT_SEND_MESSAGE(403, "권한이 없어 메시지를 보낼 수 없습니다.");
 
     private final int status;
     private final String message;

--- a/src/main/java/yuquiz/domain/chatRoom/exception/ChatRoomExceptionCode.java
+++ b/src/main/java/yuquiz/domain/chatRoom/exception/ChatRoomExceptionCode.java
@@ -1,0 +1,27 @@
+package yuquiz.domain.study.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum StudyExceptionCode implements ExceptionCode {
+
+    INVALID_ID(404, "존재하지 않는 스터디입니다."),
+    UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
+    ALREADY_REGISTERED(409, "이미 가입되었습니다."),
+    REQUEST_NOT_EXIST(404, "존재하지 않는 가입 신청입니다.");
+
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/yuquiz/domain/chatRoom/exception/ChatSendException.java
+++ b/src/main/java/yuquiz/domain/chatRoom/exception/ChatSendException.java
@@ -1,0 +1,2 @@
+package yuquiz.domain.chatRoom.exception;public class ChatSendException {
+}

--- a/src/main/java/yuquiz/domain/chatRoom/exception/ChatSendException.java
+++ b/src/main/java/yuquiz/domain/chatRoom/exception/ChatSendException.java
@@ -1,2 +1,10 @@
-package yuquiz.domain.chatRoom.exception;public class ChatSendException {
+package yuquiz.domain.chatRoom.exception;
+
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+public class ChatSendException extends RuntimeException {
+
+    public ChatSendException(ExceptionCode exceptionCode) {
+        super(exceptionCode.getMessage());
+    }
 }

--- a/src/main/java/yuquiz/domain/chatRoom/repository/ChatRoomRepository.java
+++ b/src/main/java/yuquiz/domain/chatRoom/repository/ChatRoomRepository.java
@@ -3,5 +3,9 @@ package yuquiz.domain.chatRoom.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.chatRoom.entity.ChatRoom;
 
+import java.util.Optional;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+    Optional<ChatRoom> findByStudy_Id(Long studyId);
 }

--- a/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
@@ -1,2 +1,41 @@
-package yuquiz.domain.chatRoom.service;public class ChatRoomService {
+package yuquiz.domain.chatRoom.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import yuquiz.common.utils.redis.RedisUtil;
+import yuquiz.domain.studyUser.repository.StudyUserRepository;
+
+import static yuquiz.common.utils.redis.RedisProperties.CHAT_EXPIRATION_TIME;
+import static yuquiz.common.utils.redis.RedisProperties.CHAT_PREFIX;
+import static yuquiz.common.utils.redis.RedisProperties.MEMBER_PREFIX;
+
+@RequiredArgsConstructor
+@Service
+public class ChatRoomService {
+
+    private final StudyUserRepository studyUserRepository;
+    private final RedisUtil redisUtil;
+
+    /* 채팅방 입장 시, 권한 확인 */
+    @Transactional(readOnly = true)
+    public boolean isChatMemberForEnterChat(Long userId, Long roomId) {
+
+        return studyUserRepository.existsByChatRoom_IdAndUser_Id(roomId, userId);
+    }
+
+    /* 채팅방 권한 인증 성공 시, redis에 캐싱 */
+    public void saveChatMemberInRedis(Long userId, Long roomId) {
+
+        String key = CHAT_PREFIX + roomId + MEMBER_PREFIX + userId;
+        redisUtil.set(key, userId);
+        redisUtil.expire(key, CHAT_EXPIRATION_TIME);
+    }
+
+    /* 채팅 보낼 때, redis에 캐싱되어 있는 값으로 확인 */
+    public boolean isChatMemberForSendMessage(Long userId, Long roomId) {
+
+        String key = CHAT_PREFIX + roomId + MEMBER_PREFIX + userId;
+        return redisUtil.existed(key);
+    }
 }

--- a/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
@@ -1,0 +1,2 @@
+package yuquiz.domain.chatRoom.service;public class ChatRoomService {
+}

--- a/src/main/java/yuquiz/domain/chatRoom/websocket/error/StompErrorHandler.java
+++ b/src/main/java/yuquiz/domain/chatRoom/websocket/error/StompErrorHandler.java
@@ -17,6 +17,8 @@ import yuquiz.common.exception.JwtExpiredException;
 import yuquiz.common.exception.dto.ExceptionsRes;
 import yuquiz.common.exception.exceptionCode.ExceptionCode;
 import yuquiz.common.exception.exceptionCode.JwtExceptionCode;
+import yuquiz.domain.chatRoom.exception.ChatRoomExceptionCode;
+import yuquiz.domain.chatRoom.exception.ChatSendException;
 import yuquiz.domain.user.exception.UserExceptionCode;
 
 import java.nio.charset.StandardCharsets;
@@ -47,6 +49,10 @@ public class StompErrorHandler extends StompSubProtocolErrorHandler {
 
         if (rootCause instanceof JwtException) {
             return sendErrorMessage(JwtExceptionCode.INVALID_ACCESS_TOKEN);
+        }
+
+        if (rootCause instanceof ChatSendException) {
+            return sendErrorMessage(ChatRoomExceptionCode.CANNOT_SEND_MESSAGE);
         }
 
         return super.handleClientMessageProcessingError(clientMessage, ex);

--- a/src/main/java/yuquiz/domain/chatRoom/websocket/interceptor/SocketChannelInterceptor.java
+++ b/src/main/java/yuquiz/domain/chatRoom/websocket/interceptor/SocketChannelInterceptor.java
@@ -24,7 +24,7 @@ import static yuquiz.common.utils.jwt.JwtProperties.TOKEN_PREFIX;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class JwtChannelInterceptor implements ChannelInterceptor {
+public class SocketChannelInterceptor implements ChannelInterceptor {
 
     private final JwtProvider jwtProvider;
     private final BlackListTokenService blackListTokenService;

--- a/src/main/java/yuquiz/domain/study/dto/StudyReq.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyReq.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import yuquiz.domain.chatRoom.entity.ChatRoom;
 import yuquiz.domain.study.entity.Study;
 import yuquiz.domain.study.entity.StudyState;
 import yuquiz.domain.user.entity.User;
@@ -31,12 +32,13 @@ public record StudyReq(
 
 ) {
     //todo : ChatRoom 개발 되면 추가하기
-    public Study toEntity(User leader) {
+    public Study toEntity(User leader, ChatRoom chatRoom) {
         return Study.builder()
                 .studyName(name)
                 .description(description)
                 .registerDuration(registerDuration)
                 .maxUser(maxUser)
+                .chatRoom(chatRoom)
                 .leader(leader)
                 .build();
     }

--- a/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
+++ b/src/main/java/yuquiz/domain/studyUser/entity/StudyUser.java
@@ -56,8 +56,9 @@ public class StudyUser {
         this.state = state;
     }
 
-    public void accept() {
+    public void accept(ChatRoom chatRoom) {
         this.joinedAt = LocalDateTime.now();
         this.state = UserState.REGISTERED;
+        this.chatRoom = chatRoom;
     }
 }

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
     boolean existsByStudy_IdAndUser_Id(Long studyId, Long userId);
 
+    boolean existsByChatRoom_IdAndUser_Id(Long roomId, Long userId);
+
     Optional<StudyUser> findStudyUserByStudy_IdAndUser_IdAndState(Long studyId, Long userId, UserState state);
 
     List<StudyUser> findByStudyIdAndState(Long studyId, UserState state);


### PR DESCRIPTION
## 개요
채팅에 참여하지 않고, 외부에서 악의적인 사용자가 채팅방에 메시지를 보내는 것을 막기 위한 로직 추가

## 구현사항
- 스터디 생성 및 스터디 가입 수락 시, 채팅방 설정
- 채팅 전송 시, 권한 확인 로직 추가
- CONNECT 성공 시, redis에 채팅방, 사용자 id를 이용하여 저장 (임시로 6시간 설정)
- 채팅 메시지를 보낼 때(SEND), redis에 캐싱되어 있는 값으로 확인. 

## 기타
 - 아마 사용자가 6시간 동안 연속 접속할리는 없겠지만, 추후에 예전에 원영님께서 말씀하신 `redis에 없다? db를 확인 한 번 더한다.` 라는 방향을 고려할만함.
 - 메시징 컨트롤러에서 권한을 확인할까는 고민을 했었음. 그렇게 하지 않은 이유는 아래와 같음.
      1. 또 다른 구독 채널을 통해 '권한이 없다'는 문구를 보내야함.
      2. 보통, 웹소켓에 연결을 실패하여 채팅을 보낼 수 없거나, 외부에서 웹소켓 연결 없이 메시지를 보내는 것일텐데, '구독 채널로 보낸다'는 것은 적절하지 않음.
      3. 메시징 컨트롤러에 접근하기 전, 인터셉터에서 처리하는 것이 미세하지만 좀 더 빠름.

## 테스트
이 전과 같이, 다른 프로젝트에서 테스트 한 결과입니다.

1. 스터디 가입 신청 시 (채팅방 설정 x)
![image](https://github.com/user-attachments/assets/e466ba32-a901-4f93-adb2-8588ba096b2e)

2. 스터디 가입 수락할 시 (채팅방 설정 o)
![image](https://github.com/user-attachments/assets/b513533e-3b78-460c-9ec1-55abeb445060)

3. 채팅 전송에 대한 권한이 없을 시
![image](https://github.com/user-attachments/assets/6137d616-5326-45eb-9478-8df580c076f7)


