### PR TITLE
feat: 채팅방 연결 해제 로직 추가

### DIFF
--- a/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
+++ b/src/main/java/yuquiz/domain/chatRoom/service/ChatRoomService.java
@@ -38,4 +38,11 @@ public class ChatRoomService {
         String key = CHAT_PREFIX + roomId + MEMBER_PREFIX + userId;
         return redisUtil.existed(key);
     }
+
+    /* 채팅방 퇴장 시 */
+    public void exitChatRoom(Long userId, Long roomId) {
+
+        String key = CHAT_PREFIX + roomId + MEMBER_PREFIX + userId;
+        redisUtil.del(key);
+    }
 }

--- a/src/main/java/yuquiz/domain/chatRoom/websocket/interceptor/SocketChannelInterceptor.java
+++ b/src/main/java/yuquiz/domain/chatRoom/websocket/interceptor/SocketChannelInterceptor.java
@@ -43,6 +43,12 @@ public class SocketChannelInterceptor implements ChannelInterceptor {
         if (StompCommand.SEND.equals(accessor.getCommand())) {
             handleSend(accessor);
         }
+
+        // 웹소켓 연결 끊을 시
+        if (StompCommand.DISCONNECT.equals(accessor.getCommand())) {
+            handleDisConnect(accessor);
+        }
+
         return message;
     }
 
@@ -70,6 +76,18 @@ public class SocketChannelInterceptor implements ChannelInterceptor {
         if (!chatRoomService.isChatMemberForSendMessage(userId, roomId)) {
             throw new ChatSendException(ChatRoomExceptionCode.CANNOT_SEND_MESSAGE);
         }
+    }
+
+    private void handleDisConnect(StompHeaderAccessor accessor) {
+        String roomIdStr = accessor.getFirstNativeHeader("roomId");
+
+        if (roomIdStr == null) {  // 서버에서 보낸 자동 disconnect는 무시
+            return;
+        }
+        Long roomId = Long.valueOf(roomIdStr);
+        Long userId = getUserId(accessor);
+
+        chatRoomService.exitChatRoom(userId, roomId);
     }
 
     private Long getRoomId(StompHeaderAccessor accessor) {


### PR DESCRIPTION
## 개요
사용자가 채팅방을 나갈 시, 캐싱되어 있던 사용자의 정보가 필요없어짐. 그 정보를 삭제.
 - TTL을 사용하긴 하였지만, 추후에 확인하지 않은 채팅기록 표시가 필요할 시 연결 해제에 대한 시간이 필요함

## 구현사항
- 캐싱 정보 삭제
- 웹소켓 해제(DISCONNECT) 인터셉터 로직 추가

## 기타
웹소켓 해제를 위한 인터셉터에서 `handleDisConnect`로직이 있습니다.
클래스 내에 헤더에서 roomId를 가지고 오는 `getRoomId()`가 있지만, 사용하지 않고 null인지 확인하는 이유는 웹소켓 서버에서의 요청때문입니다.

캐싱 정보를 삭제하기 위해서는 프론트에서 헤더를 보내줘야 하기에 프론트에서 요청을 해야합니다.
하지만, 웹소켓 서버 자체에서도 연결이 끊긴 것을 감지하여 요청을 자동으로 보내기 때문에, 파싱하여 Long 타입으로 변환하는 과정에서 에러 문구가 발생하게 됩니다.

그래서, 프론트의 요청 + 웹소켓 서버의 요청 2번이 오기 때문에, 웹소켓 서버의 요청은 무시하기 위해 null인지 검사를 한 후, 진행을 합니다.

## 테스트
* 다른 프로젝트에서의 테스트 입니다.

redis의 정보이고, 위에서 (2)번이 사용자id와 채팅방id에 대한 정보를 캐싱한 것이고,
아래에는 연결을 해제하고 난 후의 모습입니다.

<img width="182" alt="스크린샷 2024-10-19 오전 2 43 46" src="https://github.com/user-attachments/assets/7ea23170-6f85-469f-b827-4eb98d2bd52e">

