### PR TITLE
feat: 관리자 권한으로 사용자 조회시 정지 여부 반환 및 조회 로직 리팩토링

### DIFF
--- a/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
+++ b/src/main/java/yuquiz/domain/post/controller/AdminPostController.java
@@ -19,8 +19,8 @@ public class AdminPostController implements AdminPostApi {
     private final AdminPostService adminPostService;
 
     @GetMapping
-    public ResponseEntity<?> getAllPosts(@RequestParam PostSortType sort,
-                                                  @RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllPosts(@RequestParam(value = "sort", defaultValue = "DATE_DESC") PostSortType sort,
+                                         @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page) {
 
         Page<PostSummaryRes> posts = adminPostService.getAllPosts(sort, page);
 

--- a/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
+++ b/src/main/java/yuquiz/domain/quiz/controller/AdminQuizController.java
@@ -19,8 +19,8 @@ public class AdminQuizController implements AdminQuizApi {
     private final AdminQuizService adminQuizService;
 
     @GetMapping
-    public ResponseEntity<?> getAllQuizzes(@RequestParam QuizSortType sort,
-                                           @RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllQuizzes(@RequestParam(value = "sort", defaultValue = "DATE_DESC") QuizSortType sort,
+                                           @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page) {
 
         Page<AdminQuizSummaryRes> quizzes = adminQuizService.getAllQuizzes(sort, page);
 

--- a/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
+++ b/src/main/java/yuquiz/domain/user/controller/AdminUserController.java
@@ -22,8 +22,8 @@ public class AdminUserController implements AdminUserApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<?> getAllUsers(@RequestParam UserSortType sort,
-                                         @RequestParam @Min(0) Integer page) {
+    public ResponseEntity<?> getAllUsers(@RequestParam(value = "sort", defaultValue = "NICK_ASC") UserSortType sort,
+                                         @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page) {
 
         Page<UserSummaryRes> users = adminUserService.getAllUsers(sort, page);
 
@@ -41,7 +41,7 @@ public class AdminUserController implements AdminUserApi {
     @Override
     @PatchMapping("/{userId}")
     public ResponseEntity<?> suspendUser(@PathVariable Long userId,
-                                         @RequestParam UserStatusReq status){
+                                         @RequestParam UserStatusReq status) {
 
         adminUserService.updateSuspendStatus(userId, status);
 

--- a/src/main/java/yuquiz/domain/user/dto/res/UserSummaryRes.java
+++ b/src/main/java/yuquiz/domain/user/dto/res/UserSummaryRes.java
@@ -9,15 +9,23 @@ public record UserSummaryRes(
         String username,
         String nickname,
         String email,
-        LocalDateTime createdAt
+        LocalDateTime createdAt,
+        boolean isSuspended
 ) {
     public static UserSummaryRes fromEntity(User user) {
+        boolean isSuspended = false;
+        LocalDateTime unlockedAt = user.getUnlockedAt();
+        if (unlockedAt != null && unlockedAt.isAfter(LocalDateTime.now())) {
+            isSuspended = true;
+        }
+
         return new UserSummaryRes(
                 user.getId(),
                 user.getUsername(),
                 user.getNickname(),
                 user.getEmail(),
-                user.getCreatedAt()
+                user.getCreatedAt(),
+                isSuspended
         );
     }
 }


### PR DESCRIPTION
## 개요

관리자 권한으로 사용자 조회시 정지 여부를 보내달라는 요구사항이 있어 적용
추가로 게시글, 퀴즈, 사용자 조회 시 정렬기준 및 페이지의 기본값을 설정

## 구현사항

- 사용자 조회시 정지여부도 함께 반환
- 게시글, 퀴즈, 사용자 조회 시 정렬 기준 및 페이지의 기본값을 설정

## 테스트
1. 사용자 조회 시 정지여부도 함께 반환 (기본값 설정)
<img width="839" alt="스크린샷 2024-11-05 오후 9 44 05" src="https://github.com/user-attachments/assets/33334e8a-1699-474d-9253-f86b45b25d38">

2. 퀴즈 조회시 기본값 설정
<img width="842" alt="스크린샷 2024-11-05 오후 9 43 27" src="https://github.com/user-attachments/assets/0b169c9e-1e5a-485e-b112-77fd57c6bdb4">

3. 게시글 조회시 기본값 설정
<img width="836" alt="image" src="https://github.com/user-attachments/assets/f387652a-0640-4f62-bbaa-d52b9642c020">