### PR TITLE
feat: 스터디 문제집 검색 및 게시물 관련 기능 구현

### DIFF
--- a/src/main/java/yuquiz/domain/post/entity/Post.java
+++ b/src/main/java/yuquiz/domain/post/entity/Post.java
@@ -10,6 +10,8 @@ import yuquiz.common.entity.BaseTimeEntity;
 import yuquiz.domain.category.entity.Category;
 import yuquiz.domain.comment.entity.Comment;
 import yuquiz.domain.post.dto.PostReq;
+import yuquiz.domain.studyPost.entity.StudyPost;
+import yuquiz.domain.studyUser.entity.StudyUser;
 import yuquiz.domain.user.entity.User;
 
 import java.util.ArrayList;
@@ -38,6 +40,9 @@ public class Post extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     private List<Comment> comments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
+    private List<StudyPost> studyPosts = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")

--- a/src/main/java/yuquiz/domain/post/service/PostService.java
+++ b/src/main/java/yuquiz/domain/post/service/PostService.java
@@ -35,7 +35,7 @@ public class PostService {
     private final Integer POST_PER_PAGE = 20;
 
     @Transactional
-    public void createPost(PostReq postReq, Long userId) {
+    public Post createPost(PostReq postReq, Long userId) {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
@@ -44,7 +44,7 @@ public class PostService {
                 .orElseThrow(() -> new CustomException(CategoryExceptionCode.INVALID_ID));
 
         Post post = postReq.toEntity(user, category);
-        postRepository.save(post);
+        return postRepository.save(post);
     }
 
     @Transactional

--- a/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
@@ -18,4 +18,9 @@ public interface SeriesRepository extends JpaRepository<Series, Long> {
             "where s.study is null " +
             "and (:keyword is null or s.name like %:keyword%)")
     Page<Series> findByKeywordAndStudyIsNull(@Param("keyword") String keyword, Pageable pageable);
+
+    @Query("select s from Series s " +
+            "where s.study.id = :study " +
+            "and (:keyword is null or s.name like %:keyword%)")
+    Page<Series> findByStudyAndKeywordAndStudyIsNull(@Param("keyword") String keyword, @Param("study") Long studyId, Pageable pageable);
 }

--- a/src/main/java/yuquiz/domain/series/service/SeriesService.java
+++ b/src/main/java/yuquiz/domain/series/service/SeriesService.java
@@ -110,6 +110,16 @@ public class SeriesService {
         return series.map(SeriesSummaryRes::fromEntity);
     }
 
+    @Transactional(readOnly = true)
+    public Page<SeriesSummaryRes> getStudySeriesSummary(String keyword, Long studyId, SeriesSortType sort, Integer page) {
+
+        Pageable pageable = PageRequest.of(page, SERIES_PER_PAGE, sort.getSort());
+
+        Page<Series> studySeries = seriesRepository.findByStudyAndKeywordAndStudyIsNull(keyword, studyId, pageable);
+
+        return studySeries.map(SeriesSummaryRes::fromEntity);
+    }
+
     private boolean validateCreator(Long seriesId, Long userId) {
         return seriesRepository.findCreatorIdById(seriesId)
                 .map(creatorId -> creatorId.equals(userId))

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -131,7 +131,17 @@ public class StudyController implements StudyApi {
                                                @RequestBody PostReq postReq,
                                                @AuthenticationPrincipal SecurityUserDetails userDetails) {
 
-        studyService.createStudyNotice(postReq, userDetails.getId(), studyId);
+        studyService.createStudyPost(postReq, userDetails.getId(), studyId, true);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 생성되었습니다."));
+    }
+
+    @PostMapping("/{studyId}/post")
+    public ResponseEntity<?> createStudyPost(@PathVariable(value = "studyId") Long studyId,
+                                               @RequestBody PostReq postReq,
+                                               @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        studyService.createStudyPost(postReq, userDetails.getId(), studyId, false);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 생성되었습니다."));
     }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -128,7 +128,7 @@ public class StudyController implements StudyApi {
 
     @PostMapping("/{studyId}/notice")
     public ResponseEntity<?> createStudyNotice(@PathVariable(value = "studyId") Long studyId,
-                                               @RequestBody PostReq postReq,
+                                               @Valid @RequestBody PostReq postReq,
                                                @AuthenticationPrincipal SecurityUserDetails userDetails) {
 
         studyService.createStudyPost(postReq, userDetails.getId(), studyId, true);
@@ -138,8 +138,8 @@ public class StudyController implements StudyApi {
 
     @PostMapping("/{studyId}/post")
     public ResponseEntity<?> createStudyPost(@PathVariable(value = "studyId") Long studyId,
-                                               @RequestBody PostReq postReq,
-                                               @AuthenticationPrincipal SecurityUserDetails userDetails) {
+                                             @Valid @RequestBody PostReq postReq,
+                                             @AuthenticationPrincipal SecurityUserDetails userDetails) {
 
         studyService.createStudyPost(postReq, userDetails.getId(), studyId, false);
 

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.study.api.StudyApi;
 import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
@@ -112,5 +113,15 @@ public class StudyController implements StudyApi {
         studyService.deleteUser(studyId, userDetails.getId(), deleteUserId);
 
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @GetMapping("/{studyId}/series")
+    public ResponseEntity<?> getStudySeries(@PathVariable(value = "studyId") Long studyId,
+                                            @RequestParam(value = "sort", defaultValue = "DATE_DESC") SeriesSortType sort,
+                                            @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                            @RequestParam(value = "keyword", defaultValue = "") String keyword,
+                                            @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(studyService.getStudySeries(keyword, studyId, userDetails.getId(), sort, page));
     }
 }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.post.dto.PostReq;
 import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.study.api.StudyApi;
 import yuquiz.domain.study.dto.StudyFilter;
@@ -123,5 +124,15 @@ public class StudyController implements StudyApi {
                                             @AuthenticationPrincipal SecurityUserDetails userDetails) {
 
         return ResponseEntity.status(HttpStatus.OK).body(studyService.getStudySeries(keyword, studyId, userDetails.getId(), sort, page));
+    }
+
+    @PostMapping("/{studyId}/notice")
+    public ResponseEntity<?> createStudyNotice(@PathVariable(value = "studyId") Long studyId,
+                                               @RequestBody PostReq postReq,
+                                               @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        studyService.createStudyNotice(postReq, userDetails.getId(), studyId);
+
+        return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 생성되었습니다."));
     }
 }

--- a/src/main/java/yuquiz/domain/study/entity/Study.java
+++ b/src/main/java/yuquiz/domain/study/entity/Study.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 import yuquiz.common.entity.BaseTimeEntity;
 import yuquiz.domain.chatRoom.entity.ChatRoom;
 import yuquiz.domain.study.dto.StudyReq;
+import yuquiz.domain.studyPost.entity.StudyPost;
 import yuquiz.domain.studyUser.entity.StudyUser;
 import yuquiz.domain.user.entity.User;
 
@@ -36,6 +37,9 @@ public class Study extends BaseTimeEntity {
 
     @OneToMany(mappedBy = "study", cascade = CascadeType.REMOVE)
     private List<StudyUser> studyUsers = new ArrayList<>();
+
+    @OneToMany(mappedBy = "study", cascade = CascadeType.REMOVE)
+    private List<StudyPost> studyPosts = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "leader_id")

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -189,15 +189,17 @@ public class StudyService {
 
     @Transactional
     public void createStudyPost(PostReq postReq, Long userId, Long studyId, boolean isNotice) {
-        if (isNotice) {
-            if (!validateLeader(studyId, userId)) {
-                throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
-            }
-        } else {
-            if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
-                throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
-            }
-        }
+      boolean isAuthorized;
+      
+      if (isNotice) {
+          isAuthorized = validateLeader(studyId, userId);
+      } else {
+          isAuthorized = studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED);
+      }
+      
+      if (!isAuthorized) {
+          throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+      }
 
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -188,9 +188,15 @@ public class StudyService {
     }
 
     @Transactional
-    public void createStudyNotice(PostReq postReq, Long userId, Long studyId) {
-        if (!validateLeader(studyId, userId)) {
-            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+    public void createStudyPost(PostReq postReq, Long userId, Long studyId, boolean isNotice) {
+        if (isNotice) {
+            if (!validateLeader(studyId, userId)) {
+                throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+            }
+        } else {
+            if (!studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+                throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+            }
         }
 
         Study study = studyRepository.findById(studyId)
@@ -201,7 +207,7 @@ public class StudyService {
         StudyPost studyPost = StudyPost.builder()
                 .study(study)
                 .post(post)
-                .type(StudyPostType.NOTICE)
+                .type(isNotice ? StudyPostType.NOTICE : StudyPostType.NORMAL)
                 .build();
 
         studyPostRepository.save(studyPost);

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -160,7 +160,7 @@ public class StudyService {
 
     @Transactional(readOnly = true)
     public List<StudyUserRes> getMembers(Long studyId, Long userId) {
-        if (!studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+        if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
             throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
         }
 
@@ -180,7 +180,7 @@ public class StudyService {
 
     @Transactional(readOnly = true)
     public Page<SeriesSummaryRes> getStudySeries(String keyword, Long studyId, Long userId, SeriesSortType sort, Integer page) {
-        if (!studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+        if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
             throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
         }
 
@@ -194,7 +194,7 @@ public class StudyService {
                 throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
             }
         } else {
-            if (!studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+            if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
                 throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
             }
         }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -9,6 +9,9 @@ import yuquiz.common.exception.CustomException;
 import yuquiz.domain.chatRoom.entity.ChatRoom;
 import yuquiz.domain.chatRoom.exception.ChatRoomExceptionCode;
 import yuquiz.domain.chatRoom.repository.ChatRoomRepository;
+import yuquiz.domain.series.dto.SeriesSortType;
+import yuquiz.domain.series.dto.SeriesSummaryRes;
+import yuquiz.domain.series.service.SeriesService;
 import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
 import yuquiz.domain.study.dto.StudyRequestRes;
@@ -36,6 +39,7 @@ public class StudyService {
     private final StudyUserRepository studyUserRepository;
     private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
+    private final SeriesService seriesService;
 
     @Transactional
     public void createStudy(StudyReq studyReq, Long userId) {
@@ -164,6 +168,15 @@ public class StudyService {
         }
 
         studyUserRepository.deleteByStudy_IdAndUser_Id(studyId, deleteId);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<SeriesSummaryRes> getStudySeries(String keyword, Long studyId, Long userId, SeriesSortType sort, Integer page) {
+        if (!studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId)) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        return seriesService.getStudySeriesSummary(keyword, studyId, sort, page);
     }
 
     private boolean validateLeader(Long studyId, Long userId) {

--- a/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
+++ b/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
@@ -1,7 +1,6 @@
 package yuquiz.domain.studyPost.entity;
 
 import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
@@ -14,13 +13,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import yuquiz.domain.post.entity.Post;
 import yuquiz.domain.study.entity.Study;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EntityListeners(AuditingEntityListener.class)
 @Entity
 public class StudyPost {
 

--- a/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
+++ b/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
@@ -1,0 +1,45 @@
+package yuquiz.domain.studyPost.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import yuquiz.domain.post.entity.Post;
+import yuquiz.domain.study.entity.Study;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class StudyPost {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private StudyPostType type;
+
+    @Builder
+    public StudyPost(Study study, Post post, StudyPostType type){
+        this.study = study;
+        this.post = post;
+        this.type = type;
+    }
+}

--- a/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
+++ b/src/main/java/yuquiz/domain/studyPost/entity/StudyPost.java
@@ -2,6 +2,8 @@ package yuquiz.domain.studyPost.entity;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -34,6 +36,7 @@ public class StudyPost {
     @JoinColumn(name = "post_id")
     private Post post;
 
+    @Enumerated(EnumType.STRING)
     private StudyPostType type;
 
     @Builder

--- a/src/main/java/yuquiz/domain/studyPost/entity/StudyPostType.java
+++ b/src/main/java/yuquiz/domain/studyPost/entity/StudyPostType.java
@@ -1,0 +1,5 @@
+package yuquiz.domain.studyPost.entity;
+
+public enum StudyPostType {
+    NORMAL, NOTICE
+}

--- a/src/main/java/yuquiz/domain/studyPost/repository/StudyPostRepository.java
+++ b/src/main/java/yuquiz/domain/studyPost/repository/StudyPostRepository.java
@@ -1,0 +1,8 @@
+package yuquiz.domain.studyPost.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yuquiz.domain.studyPost.entity.StudyPost;
+
+public interface StudyPostRepository extends JpaRepository<StudyPost, Long> {
+
+}

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -10,6 +10,8 @@ import java.util.Optional;
 public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
     boolean existsByStudy_IdAndUser_Id(Long studyId, Long userId);
 
+    boolean existsByStudy_IdAndUser_IdAndState(Long studyId, Long userId, UserState state);
+
     boolean existsByChatRoom_IdAndUser_Id(Long roomId, Long userId);
 
     Optional<StudyUser> findStudyUserByStudy_IdAndUser_IdAndState(Long studyId, Long userId, UserState state);


### PR DESCRIPTION
## 개요
스터디 문제집 검색 및 게시물 관련 기능 구현

## 구현사항
* 스터디 문제집 검색 기능 구현
* 스터디 공지, 게시글 작성 기능 구현
  * 기존의 게시글 작성 로직을 이용해서 구현하였습니다.
* 기존 코드의 스터디원 검증 로직을 수정
  * 스터디 신청 상태에서도 스터디원으로 인식하는 문제 해결

## 테스트
스터디디 문제집 검색 기능
<img width="631" alt="image" src="https://github.com/user-attachments/assets/54d1198d-b0f8-4c21-bc9c-f14717c248ea">

권한 없음 (스터디원이 아님)
<img width="650" alt="image" src="https://github.com/user-attachments/assets/ea38c5f8-1cd5-4d9f-ac53-04610c012c42">

스터디 공지 작성
<img width="634" alt="image" src="https://github.com/user-attachments/assets/8349a157-e81c-4d68-95ec-f1b6ff1e731b">

스터디 장이 아님
<img width="649" alt="image" src="https://github.com/user-attachments/assets/3e6e5174-7274-40b8-a007-cd4fc577b916">

스터디 게시글 작성
<img width="633" alt="image" src="https://github.com/user-attachments/assets/7587a705-3fac-4c65-a377-5debd0eeff0f">
