### PR TITLE
feat: 스터디 게시물 조회 구현

### DIFF
--- a/src/main/java/yuquiz/domain/post/repository/CustomPostRepository.java
+++ b/src/main/java/yuquiz/domain/post/repository/CustomPostRepository.java
@@ -4,7 +4,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import yuquiz.domain.post.dto.PostSortType;
 import yuquiz.domain.post.entity.Post;
+import yuquiz.domain.studyPost.entity.StudyPostType;
 
 public interface CustomPostRepository {
     Page<Post> getPosts(String keyword, Long categoryId, Pageable pageable, PostSortType sort);
+
+    Page<Post> getPostsByStudy(Long studyId, StudyPostType type, String keyword, Long categoryId, Pageable pageable, PostSortType sort);
 }

--- a/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
@@ -12,6 +12,7 @@ import yuquiz.domain.post.entity.Post;
 import yuquiz.domain.studyPost.entity.StudyPostType;
 
 import java.util.List;
+import java.util.Optional;
 
 import static yuquiz.domain.post.entity.QPost.post;
 import static yuquiz.domain.studyPost.entity.QStudyPost.studyPost;
@@ -38,7 +39,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = jpaQueryFactory
+        long total = Optional.ofNullable(jpaQueryFactory
                 .select(post.count())
                 .from(post)
                 .where(
@@ -46,7 +47,9 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                         categoryEqual(categoryId),
                         post.studyPosts.isEmpty()
                 )
-                .fetchOne();
+                .fetchOne()
+        ).orElse(0L);
+
 
         return new PageImpl<>(posts, pageable, total);
     }
@@ -68,7 +71,7 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = jpaQueryFactory
+        long total = Optional.ofNullable(jpaQueryFactory
                 .select(post.count())
                 .from(post)
                 .join(post.studyPosts, studyPost)
@@ -78,7 +81,8 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
                         wordContain(keyword),
                         categoryEqual(categoryId)
                 )
-                .fetchOne();
+                .fetchOne()
+        ).orElse(0L);
 
         return new PageImpl<>(posts, pageable, total);
     }

--- a/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
@@ -16,10 +16,10 @@ import java.util.List;
 import static yuquiz.domain.post.entity.QPost.post;
 import static yuquiz.domain.studyPost.entity.QStudyPost.studyPost;
 
-public class CustomPostRepositoryImpl implements CustomPostRepository{
+public class CustomPostRepositoryImpl implements CustomPostRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
-    public CustomPostRepositoryImpl(EntityManager entityManager){
+    public CustomPostRepositoryImpl(EntityManager entityManager) {
         this.jpaQueryFactory = new JPAQueryFactory(entityManager);
     }
 
@@ -28,7 +28,11 @@ public class CustomPostRepositoryImpl implements CustomPostRepository{
         List<Post> posts = jpaQueryFactory
                 .select(post)
                 .from(post)
-                .where(wordContain(keyword), categoryEqual(categoryId))
+                .where(
+                        wordContain(keyword),
+                        categoryEqual(categoryId),
+                        post.studyPosts.isEmpty()
+                )
                 .orderBy(sort.getOrder())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -37,7 +41,11 @@ public class CustomPostRepositoryImpl implements CustomPostRepository{
         long total = jpaQueryFactory
                 .select(post.count())
                 .from(post)
-                .where(wordContain(keyword), categoryEqual(categoryId))
+                .where(
+                        wordContain(keyword),
+                        categoryEqual(categoryId),
+                        post.studyPosts.isEmpty()
+                )
                 .fetchOne();
 
         return new PageImpl<>(posts, pageable, total);

--- a/src/main/java/yuquiz/domain/quiz/repository/CustomQuizRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/quiz/repository/CustomQuizRepositoryImpl.java
@@ -11,11 +11,12 @@ import yuquiz.domain.quiz.dto.quiz.QuizSortType;
 import yuquiz.domain.quiz.entity.Quiz;
 
 import java.util.List;
+import java.util.Optional;
 
 import static yuquiz.domain.quiz.entity.QQuiz.quiz;
 
 
-public class CustomQuizRepositoryImpl implements CustomQuizRepository{
+public class CustomQuizRepositoryImpl implements CustomQuizRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     public CustomQuizRepositoryImpl(EntityManager entityManager) {
@@ -33,11 +34,13 @@ public class CustomQuizRepositoryImpl implements CustomQuizRepository{
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = jpaQueryFactory
-                .select(quiz.count())
-                .from(quiz)
-                .where(wordContain(keyword), subjectEqual(subjectId))
-                .fetchOne();
+        long total = Optional.ofNullable(
+                jpaQueryFactory
+                        .select(quiz.count())
+                        .from(quiz)
+                        .where(wordContain(keyword), subjectEqual(subjectId))
+                        .fetchOne()
+        ).orElse(0L);
 
         return new PageImpl<>(quizzes, pageable, total);
     }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -21,6 +21,7 @@ import yuquiz.domain.study.dto.StudyReq;
 import yuquiz.domain.study.dto.StudySortType;
 import yuquiz.domain.study.dto.StudySummaryRes;
 import yuquiz.domain.study.service.StudyService;
+import yuquiz.domain.studyPost.entity.StudyPostType;
 import yuquiz.security.auth.SecurityUserDetails;
 
 @RestController
@@ -149,6 +150,18 @@ public class StudyController implements StudyApi {
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 생성되었습니다."));
     }
 
+    @GetMapping("/{studyId}/notice")
+    public ResponseEntity<?> getStudyNotices(@PathVariable(value = "studyId") Long studyId,
+                                           @RequestParam(value = "keyword", required = false) String keyword,
+                                           @RequestParam(value = "sort", defaultValue = "DATE_DESC") PostSortType sort,
+                                           @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                           @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        Page<PostSummaryRes> posts = studyService.getStudyPosts(studyId, userDetails.getId(), StudyPostType.NOTICE, keyword, sort, page);
+
+        return ResponseEntity.status(HttpStatus.OK).body(posts);
+    }
+
     @GetMapping("/{studyId}/post")
     public ResponseEntity<?> getStudyPosts(@PathVariable(value = "studyId") Long studyId,
                                            @RequestParam(value = "keyword", required = false) String keyword,
@@ -156,7 +169,7 @@ public class StudyController implements StudyApi {
                                            @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
                                            @AuthenticationPrincipal SecurityUserDetails userDetails) {
 
-        Page<PostSummaryRes> posts = studyService.getStudyPosts(studyId, userDetails.getId(), keyword, sort, page);
+        Page<PostSummaryRes> posts = studyService.getStudyPosts(studyId, userDetails.getId(), StudyPostType.NORMAL, keyword, sort, page);
 
         return ResponseEntity.status(HttpStatus.OK).body(posts);
     }

--- a/src/main/java/yuquiz/domain/study/controller/StudyController.java
+++ b/src/main/java/yuquiz/domain/study/controller/StudyController.java
@@ -1,6 +1,7 @@
 package yuquiz.domain.study.controller;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.post.dto.PostReq;
+import yuquiz.domain.post.dto.PostSortType;
+import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.study.api.StudyApi;
 import yuquiz.domain.study.dto.StudyFilter;
@@ -144,5 +147,17 @@ public class StudyController implements StudyApi {
         studyService.createStudyPost(postReq, userDetails.getId(), studyId, false);
 
         return ResponseEntity.status(HttpStatus.CREATED).body(SuccessRes.from("성공적으로 생성되었습니다."));
+    }
+
+    @GetMapping("/{studyId}/post")
+    public ResponseEntity<?> getStudyPosts(@PathVariable(value = "studyId") Long studyId,
+                                           @RequestParam(value = "keyword", required = false) String keyword,
+                                           @RequestParam(value = "sort", defaultValue = "DATE_DESC") PostSortType sort,
+                                           @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                           @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        Page<PostSummaryRes> posts = studyService.getStudyPosts(studyId, userDetails.getId(), keyword, sort, page);
+
+        return ResponseEntity.status(HttpStatus.OK).body(posts);
     }
 }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -224,14 +224,14 @@ public class StudyService {
     }
 
     @Transactional(readOnly = true)
-    public Page<PostSummaryRes> getStudyPosts(Long studyId, Long userId, String keyword, PostSortType sort, Integer page) {
+    public Page<PostSummaryRes> getStudyPosts(Long studyId, Long userId, StudyPostType type, String keyword, PostSortType sort, Integer page) {
         if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
             throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
         }
 
         Pageable pageable = PageRequest.of(page, POST_PER_PAGE);
 
-        Page<Post> posts = postRepository.getPostsByStudy(studyId, StudyPostType.NORMAL, keyword,3L, pageable, sort);
+        Page<Post> posts = postRepository.getPostsByStudy(studyId, type, keyword,3L, pageable, sort);
 
         return posts.map(PostSummaryRes::fromEntity);
     }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -2,6 +2,7 @@ package yuquiz.domain.study.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -10,7 +11,10 @@ import yuquiz.domain.chatRoom.entity.ChatRoom;
 import yuquiz.domain.chatRoom.exception.ChatRoomExceptionCode;
 import yuquiz.domain.chatRoom.repository.ChatRoomRepository;
 import yuquiz.domain.post.dto.PostReq;
+import yuquiz.domain.post.dto.PostSortType;
+import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.entity.Post;
+import yuquiz.domain.post.repository.PostRepository;
 import yuquiz.domain.post.service.PostService;
 import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.series.dto.SeriesSummaryRes;
@@ -48,6 +52,9 @@ public class StudyService {
     private final SeriesService seriesService;
     private final PostService postService;
     private final StudyPostRepository studyPostRepository;
+    private final PostRepository postRepository;
+
+    private final Integer POST_PER_PAGE = 20;
 
     @Transactional
     public void createStudy(StudyReq studyReq, Long userId) {
@@ -214,6 +221,19 @@ public class StudyService {
                 .build();
 
         studyPostRepository.save(studyPost);
+    }
+
+    @Transactional(readOnly = true)
+    public Page<PostSummaryRes> getStudyPosts(Long studyId, Long userId, String keyword, PostSortType sort, Integer page) {
+        if (!studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        Pageable pageable = PageRequest.of(page, POST_PER_PAGE);
+
+        Page<Post> posts = postRepository.getPostsByStudy(studyId, StudyPostType.NORMAL, keyword,3L, pageable, sort);
+
+        return posts.map(PostSummaryRes::fromEntity);
     }
 
     private boolean validateLeader(Long studyId, Long userId) {


### PR DESCRIPTION
## 개요
스터디 게시물, 공지 조회 구현

## 구현사항
* 스터디 게시물, 공지 조회 기능 구현
* 기존 게시물 조회 로직 수정
  * 스터디 관련 게시물 조회하지 않기 위해

## 기타
현재 StudyService에 너무 많은 기능이 있는 것 같아서
나중에 게시물 관련 기능들은 StudyPostService로 옮기던지 하겠습니다.

## 테스트
스터디 게시물 조회
<img width="630" alt="image" src="https://github.com/user-attachments/assets/fdaf14dd-271b-45d5-935b-0fa8ab9d84db">

스터디 공지 조회
<img width="638" alt="image" src="https://github.com/user-attachments/assets/0e563403-38f6-4b0e-893f-b3d7e3f92552">
