### PR TITLE
feat: 스터디 관련 알림 및 알림 읽음 처리 구현

### DIFF
--- a/src/main/java/yuquiz/domain/notification/api/NotificationApi.java
+++ b/src/main/java/yuquiz/domain/notification/api/NotificationApi.java
@@ -1,0 +1,92 @@
+package yuquiz.domain.notification.api;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.notification.dto.DisplayType;
+import yuquiz.domain.notification.dto.NotificationSortType;
+import yuquiz.security.auth.SecurityUserDetails;
+
+@Tag(name = "[알림 API]", description = "알림 관련 API")
+public interface NotificationApi {
+
+    @Operation(summary = "전체 알림 조회", description = "사용자에 대한 전체 알림을 조회하는 api")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "알림 조회 성공",
+            content = @Content(mediaType = "application/json", examples = {
+                    @ExampleObject(value = """
+                            {
+                                "totalPages": 1,
+                                "totalElements": 2,
+                                "first": true,
+                                "last": true,
+                                "size": 20,
+                                "content": [
+                                    {
+                                        "id": 134,
+                                        "title": "\"아아아앙\"스터디에서 강제 퇴장 당했습니다.",
+                                        "message": "\"아아아앙\"스터디에서 강제 퇴장 당했습니다.",
+                                        "isChecked": false,
+                                        "redirectUrl": "/api/v1/study/16",
+                                        "createdAt": "2024-11-20T16:05:32.713949"
+                                    },
+                                    {
+                                        "id": 133,
+                                        "title": "\"아아아앙\"스터디에 참가 승인되었습니다.",
+                                        "message": "\"아아아앙\"스터디에 참가 승인되었습니다.",
+                                        "isChecked": false,
+                                        "redirectUrl": "/api/v1/study/16",
+                                        "createdAt": "2024-11-20T16:05:21.556135"
+                                    }
+                                ],
+                                "number": 0,
+                                "sort": {
+                                    "empty": false,
+                                    "sorted": true,
+                                    "unsorted": false
+                                },
+                                "pageable": {
+                                    "pageNumber": 0,
+                                    "pageSize": 20,
+                                    "sort": {
+                                        "empty": false,
+                                        "sorted": true,
+                                        "unsorted": false
+                                    },
+                                    "offset": 0,
+                                    "paged": true,
+                                    "unpaged": false
+                                },
+                                "numberOfElements": 2,
+                                "empty": false
+                            }
+                            """)
+            }))
+    })
+    ResponseEntity<?> getAllMyAlert(@AuthenticationPrincipal SecurityUserDetails userDetails,
+                                    @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                    @RequestParam(value = "sort", defaultValue = "DATE_DESC") NotificationSortType sort,
+                                    @RequestParam(value = "view", defaultValue = "UNCHECKED") DisplayType displayType);
+
+
+    @Operation(summary = "알림 읽음 처리", description = "사용자에 대한 특정 알림을 읽음 처리하는 api")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "알림 읽음 처리 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                            {
+                                "response": "성공적으로 처리하였습니다."
+                            }
+                            """)
+                    }))
+    })
+    ResponseEntity<?> readNotification(@RequestBody Long[] notifications,
+                                       @AuthenticationPrincipal SecurityUserDetails userDetails);
+}

--- a/src/main/java/yuquiz/domain/notification/controller/NotificationController.java
+++ b/src/main/java/yuquiz/domain/notification/controller/NotificationController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import yuquiz.common.api.SuccessRes;
 import yuquiz.domain.notification.dto.DisplayType;
 import yuquiz.domain.notification.dto.NotificationRes;
 import yuquiz.domain.notification.dto.NotificationSortType;
@@ -35,5 +36,14 @@ public class NotificationController {
     public SseEmitter subscribe(@AuthenticationPrincipal SecurityUserDetails userDetails,
                                 @RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
         return notificationService.subscribe(userDetails.getId(), lastEventId);
+    }
+
+    @PostMapping("/users/my/alert")
+    public ResponseEntity<?> readNotification(@RequestBody Long[] notifications,
+                                              @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        notificationService.readNotification(notifications, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(SuccessRes.from("성공적으로 처리하였습니다."));
     }
 }

--- a/src/main/java/yuquiz/domain/notification/controller/NotificationController.java
+++ b/src/main/java/yuquiz/domain/notification/controller/NotificationController.java
@@ -22,9 +22,9 @@ public class NotificationController {
 
     @GetMapping("/users/my/alert")
     public ResponseEntity<?> getAllMyAlert(@AuthenticationPrincipal SecurityUserDetails userDetails,
-                                           @RequestParam(value = "page") Integer page,
-                                           @RequestParam(value = "sort") NotificationSortType sort,
-                                           @RequestParam(value = "view") DisplayType displayType) {
+                                           @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                           @RequestParam(value = "sort", defaultValue = "DATE_DESC") NotificationSortType sort,
+                                           @RequestParam(value = "view", defaultValue = "UNCHECKED") DisplayType displayType) {
 
         Page<NotificationRes> notifications = notificationService.getAllNotification(userDetails.getId(), page, sort, displayType);
 

--- a/src/main/java/yuquiz/domain/notification/exception/NotificationExceptionCode.java
+++ b/src/main/java/yuquiz/domain/notification/exception/NotificationExceptionCode.java
@@ -1,0 +1,23 @@
+package yuquiz.domain.study.exception;
+
+import lombok.AllArgsConstructor;
+import yuquiz.common.exception.exceptionCode.ExceptionCode;
+
+@AllArgsConstructor
+public enum NotificationExceptionCode implements ExceptionCode {
+
+    INVALID_REQUEST(400, "알림 번호는 필수 사항입니다.");
+
+    private final int status;
+    private final String message;
+
+    @Override
+    public int getStatus() {
+        return status;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+}

--- a/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
@@ -9,8 +9,6 @@ import org.springframework.data.repository.query.Param;
 import yuquiz.domain.notification.entity.Notification;
 import yuquiz.domain.user.entity.User;
 
-import java.util.List;
-
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findAllByUserAndIsChecked(User user, boolean isChecked, Pageable pageable);

--- a/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
@@ -16,10 +16,9 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
     Page<Notification> findAllByUser(User user, Pageable pageable);
 
     @Modifying
-    @Query(value = "UPDATE Notification " +
-            "SET isChecked = true " +
-            "WHERE id IN :notifications AND user_id = :userId",
-            nativeQuery = true)
+    @Query(value = "UPDATE Notification n " +
+            "SET n.isChecked = true " +
+            "WHERE n.id IN :notifications AND n.user.id = :userId")
     void readNotificationsWithValidation(@Param("notifications") Long[] notifications,
                                               @Param("userId") Long userId);
 }

--- a/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/yuquiz/domain/notification/repository/NotificationRepository.java
@@ -3,12 +3,25 @@ package yuquiz.domain.notification.repository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import yuquiz.domain.notification.entity.Notification;
 import yuquiz.domain.user.entity.User;
+
+import java.util.List;
 
 public interface NotificationRepository extends JpaRepository<Notification, Long> {
 
     Page<Notification> findAllByUserAndIsChecked(User user, boolean isChecked, Pageable pageable);
 
     Page<Notification> findAllByUser(User user, Pageable pageable);
+
+    @Modifying
+    @Query(value = "UPDATE Notification " +
+            "SET isChecked = true " +
+            "WHERE id IN :notifications AND user_id = :userId",
+            nativeQuery = true)
+    void readNotificationsWithValidation(@Param("notifications") Long[] notifications,
+                                              @Param("userId") Long userId);
 }

--- a/src/main/java/yuquiz/domain/notification/service/NotificationService.java
+++ b/src/main/java/yuquiz/domain/notification/service/NotificationService.java
@@ -12,6 +12,7 @@ import yuquiz.domain.notification.dto.*;
 import yuquiz.domain.notification.entity.Notification;
 import yuquiz.domain.notification.repository.EmitterRepository;
 import yuquiz.domain.notification.repository.NotificationRepository;
+import yuquiz.domain.study.exception.NotificationExceptionCode;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
@@ -50,6 +51,15 @@ public class NotificationService {
         }
 
         return notifications.map(NotificationRes::fromEntity);
+    }
+
+    @Transactional
+    public void readNotification(Long[] notifications, Long userId) {
+        if (notifications == null || notifications.length == 0) {
+            throw new CustomException(NotificationExceptionCode.INVALID_REQUEST);
+        }
+
+        notificationRepository.readNotificationsWithValidation(notifications, userId);
     }
 
     public SseEmitter subscribe(Long userId, String lastEventId) {

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -18,7 +18,6 @@ import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.entity.Post;
 import yuquiz.domain.post.repository.PostRepository;
 import yuquiz.domain.post.service.PostService;
-import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.series.dto.SeriesSummaryRes;
 import yuquiz.domain.series.service.SeriesService;


### PR DESCRIPTION
## 개요
스터디 관련 알림 및 알림 읽음 처리 구현

## 구현사항
* 스터디 참가 신청 알림
* 스터디 참가 신청 승인 알림
* 스터디 강제 퇴장 알림
* 알림 읽음 처리

## 테스트

<!-- 테스트 내용 (선택) -->
참가 신청 알림
<img width="799" alt="image" src="https://github.com/user-attachments/assets/ea06f54a-91cc-4911-b65f-12d974b39d43">

참가 승인 알림
<img width="697" alt="image" src="https://github.com/user-attachments/assets/14fd3534-0f65-4428-b1f7-976b5b606eab">

강제 퇴장 알림
<img width="692" alt="image" src="https://github.com/user-attachments/assets/466a2745-55fc-4f38-832d-6709d0221b12">

알림 읽음 처리
<img width="670" alt="image" src="https://github.com/user-attachments/assets/945a1a38-4c02-4f80-94f6-5bea2c73eef2">
