### PR TITLE
feat: 문제집에 포함된 퀴즈 목록 조회 기능 추가

### DIFF
--- a/src/main/java/yuquiz/domain/quiz/repository/CustomTriedQuizRepository.java
+++ b/src/main/java/yuquiz/domain/quiz/repository/CustomTriedQuizRepository.java
@@ -3,7 +3,10 @@ package yuquiz.domain.quiz.repository;
 import yuquiz.domain.quiz.entity.TriedQuiz;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface CustomTriedQuizRepository {
     List<TriedQuiz> getTriedQuizzes(Long userId);
+
+    Optional<Boolean> getIsSolvedByUser_IdAndQuiz_Id(long userId, long quizId);
 }

--- a/src/main/java/yuquiz/domain/quiz/repository/CustomTriedQuizRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/quiz/repository/CustomTriedQuizRepositoryImpl.java
@@ -5,22 +5,37 @@ import jakarta.persistence.EntityManager;
 import yuquiz.domain.quiz.entity.TriedQuiz;
 
 import java.util.List;
+import java.util.Optional;
 
 import static yuquiz.domain.quiz.entity.QTriedQuiz.triedQuiz;
 
-public class CustomTriedQuizRepositoryImpl implements CustomTriedQuizRepository{
+public class CustomTriedQuizRepositoryImpl implements CustomTriedQuizRepository {
     private final JPAQueryFactory jpaQueryFactory;
 
     public CustomTriedQuizRepositoryImpl(EntityManager entityManager) {
         this.jpaQueryFactory = new JPAQueryFactory(entityManager);
     }
+
     @Override
-    public List<TriedQuiz> getTriedQuizzes(Long userId){
+    public List<TriedQuiz> getTriedQuizzes(Long userId) {
 
         return jpaQueryFactory
                 .select(triedQuiz)
                 .from(triedQuiz)
                 .where(triedQuiz.user.id.eq(userId))
                 .fetch();
+    }
+
+    @Override
+    public Optional<Boolean> getIsSolvedByUser_IdAndQuiz_Id(long userId, long quizId) {
+        return Optional.ofNullable(
+                jpaQueryFactory
+                        .select(triedQuiz.isSolved)
+                        .from(triedQuiz)
+                        .where(
+                                triedQuiz.user.id.eq(userId),
+                                triedQuiz.quiz.id.eq(quizId))
+                        .fetchOne()
+        );
     }
 }

--- a/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
+++ b/src/main/java/yuquiz/domain/quizSeries/api/QuizSeriesApi.java
@@ -6,13 +6,75 @@ import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Min;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
 import yuquiz.security.auth.SecurityUserDetails;
 
 @Tag(name = "[문제집내 퀴즈 API]", description = "문제집내 퀴즈 관련 API")
 public interface QuizSeriesApi {
+    @Operation(summary = "문제집에 포함된 퀴즈 목록 조회", description = "문제집에 포함된 퀴즈 목록을 조회하는 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "퀴즈 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "totalPages": 1,
+                                        "totalElements": 1,
+                                        "first": true,
+                                        "last": true,
+                                        "size": 20,
+                                        "content": [
+                                            {
+                                                "quizId": 7,
+                                                "quizTitle": "새로운 제목22",
+                                                "nickname": "어드민",
+                                                "createdAt": "2024-08-11T19:43:53",
+                                                "likeCount": 5,
+                                                "viewCount": 29,
+                                                "isSolved": false,
+                                                "quizType": "MULTIPLE_CHOICE"
+                                            }
+                                        ],
+                                        "number": 0,
+                                        "sort": {
+                                            "empty": true,
+                                            "unsorted": true,
+                                            "sorted": false
+                                        },
+                                        "pageable": {
+                                            "pageNumber": 0,
+                                            "pageSize": 20,
+                                            "sort": {
+                                                "empty": true,
+                                                "unsorted": true,
+                                                "sorted": false
+                                            },
+                                            "offset": 0,
+                                            "unpaged": false,
+                                            "paged": true
+                                        },
+                                        "numberOfElements": 1,
+                                        "empty": false
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getQuizzesBySeriesId(@PathVariable(value = "seriesId") Long seriesId,
+                                           @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                           @AuthenticationPrincipal SecurityUserDetails userDetails);
+
     @Operation(summary = "문제집에 퀴즈 추가", description = "문제집에 퀴즈를 추가하는 API")
     @ApiResponses({
             @ApiResponse(responseCode = "201", description = "퀴즈 추가 성공",

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -1,11 +1,14 @@
 package yuquiz.domain.quizSeries.controller;
 
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yuquiz.common.api.SuccessRes;
+import yuquiz.domain.quiz.dto.quiz.QuizSummaryRes;
 import yuquiz.domain.quizSeries.api.QuizSeriesApi;
 import yuquiz.domain.quizSeries.service.QuizSeriesService;
 import yuquiz.security.auth.SecurityUserDetails;
@@ -17,8 +20,18 @@ public class QuizSeriesController implements QuizSeriesApi {
 
     private final QuizSeriesService quizSeriesService;
 
+    @GetMapping("/quizzes/{seriesId}")
+    public ResponseEntity<?> getQuizzesBySeriesId(@PathVariable(value = "seriesId") Long seriesId,
+                                                  @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                                  @AuthenticationPrincipal SecurityUserDetails userDetails) {
+
+        Page<QuizSummaryRes> quizSeriesRes = quizSeriesService.getQuizzesBySeriesId(seriesId, page, userDetails.getId());
+
+        return ResponseEntity.status(HttpStatus.OK).body(quizSeriesRes);
+    }
+
     @Override
-    @PostMapping("/{seriesId}/{quizId}")
+    @PostMapping("/quizzes/{seriesId}/{quizId}")
     public ResponseEntity<?> addQuizToSeries(@PathVariable(value = "seriesId") Long seriesId,
                                              @PathVariable(value = "quizId") Long quizId,
                                              @AuthenticationPrincipal SecurityUserDetails userDetails) {
@@ -29,7 +42,7 @@ public class QuizSeriesController implements QuizSeriesApi {
     }
 
     @Override
-    @DeleteMapping("/{seriesId}/{quizId}")
+    @DeleteMapping("/quizzses/{seriesId}/{quizId}")
     public ResponseEntity<?> deleteQuizFromSeries(@PathVariable(value = "seriesId") Long seriesId,
                                                   @PathVariable(value = "quizId") Long quizId,
                                                   @AuthenticationPrincipal SecurityUserDetails userDetails) {

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -21,7 +21,7 @@ public class QuizSeriesController implements QuizSeriesApi {
     private final QuizSeriesService quizSeriesService;
 
     @Override
-    @GetMapping("/quizzes/{seriesId}")
+    @GetMapping("/{seriesId}/quizzes")
     public ResponseEntity<?> getQuizzesBySeriesId(@PathVariable(value = "seriesId") Long seriesId,
                                                   @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
                                                   @AuthenticationPrincipal SecurityUserDetails userDetails) {

--- a/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
+++ b/src/main/java/yuquiz/domain/quizSeries/controller/QuizSeriesController.java
@@ -20,6 +20,7 @@ public class QuizSeriesController implements QuizSeriesApi {
 
     private final QuizSeriesService quizSeriesService;
 
+    @Override
     @GetMapping("/quizzes/{seriesId}")
     public ResponseEntity<?> getQuizzesBySeriesId(@PathVariable(value = "seriesId") Long seriesId,
                                                   @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,

--- a/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepository.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepository.java
@@ -1,0 +1,11 @@
+package yuquiz.domain.quizSeries.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import yuquiz.domain.quiz.entity.Quiz;
+
+public interface CustomQuizSeriesRepository {
+
+    Page<Quiz> getQuizzesBySeriesId(long seriesId, Pageable pageable, OrderSpecifier<?> order);
+}

--- a/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepositoryImpl.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Pageable;
 import yuquiz.domain.quiz.entity.Quiz;
 
 import java.util.List;
+import java.util.Optional;
 
 import static yuquiz.domain.quiz.entity.QQuiz.quiz;
 import static yuquiz.domain.quizSeries.entity.QQuizSeries.quizSeries;
@@ -34,12 +35,13 @@ public class CustomQuizSeriesRepositoryImpl implements CustomQuizSeriesRepositor
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        long total = jpaQueryFactory
+        long total = Optional.ofNullable(jpaQueryFactory
                 .select(quiz.count())
                 .from(quizSeries)
                 .join(quizSeries.quiz, quiz)
                 .where(quizSeries.series.id.eq(seriesId))
-                .fetch().get(0);
+                .fetchOne()
+        ).orElse(0L);
 
         return new PageImpl<>(quizzes, pageable, total);
     }

--- a/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/CustomQuizSeriesRepositoryImpl.java
@@ -1,0 +1,46 @@
+package yuquiz.domain.quizSeries.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import yuquiz.domain.quiz.entity.Quiz;
+
+import java.util.List;
+
+import static yuquiz.domain.quiz.entity.QQuiz.quiz;
+import static yuquiz.domain.quizSeries.entity.QQuizSeries.quizSeries;
+
+
+public class CustomQuizSeriesRepositoryImpl implements CustomQuizSeriesRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CustomQuizSeriesRepositoryImpl(EntityManager entityManager) {
+        this.jpaQueryFactory = new JPAQueryFactory(entityManager);
+    }
+
+    @Override
+    public Page<Quiz> getQuizzesBySeriesId(long seriesId, Pageable pageable, OrderSpecifier<?> order) {
+        List<Quiz> quizzes = jpaQueryFactory
+                .select(quiz)
+                .from(quizSeries)
+                .join(quizSeries.quiz, quiz)
+                .where(quizSeries.series.id.eq(seriesId))
+                .orderBy(order)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        long total = jpaQueryFactory
+                .select(quiz.count())
+                .from(quizSeries)
+                .join(quizSeries.quiz, quiz)
+                .where(quizSeries.series.id.eq(seriesId))
+                .fetch().get(0);
+
+        return new PageImpl<>(quizzes, pageable, total);
+    }
+}

--- a/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
+++ b/src/main/java/yuquiz/domain/quizSeries/repository/QuizSeriesRepository.java
@@ -3,7 +3,7 @@ package yuquiz.domain.quizSeries.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yuquiz.domain.quizSeries.entity.QuizSeries;
 
-public interface QuizSeriesRepository extends JpaRepository<QuizSeries, Long> {
+public interface QuizSeriesRepository extends JpaRepository<QuizSeries, Long>, CustomQuizSeriesRepository {
     void deleteBySeries_IdAndQuiz_Id(Long seriesId, Long quizId);
 
     boolean existsBySeries_IdAndQuiz_Id(Long seriesId, Long quizId);

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -34,7 +34,7 @@ public class QuizSeriesService {
     private static final int QUIZ_PER_PAGE = 20;
 
     public Page<QuizSummaryRes> getQuizzesBySeriesId(Long seriesId, Integer page, long userId) {
-        if (validateMember(seriesId, userId)) {
+        if (!validateMember(seriesId, userId)) {
             throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);
         }
 

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -1,18 +1,25 @@
 package yuquiz.domain.quizSeries.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import yuquiz.common.exception.CustomException;
+import yuquiz.domain.quiz.dto.quiz.QuizSortType;
+import yuquiz.domain.quiz.dto.quiz.QuizSummaryRes;
 import yuquiz.domain.quiz.entity.Quiz;
 import yuquiz.domain.quiz.exception.QuizExceptionCode;
 import yuquiz.domain.quiz.repository.QuizRepository;
+import yuquiz.domain.quiz.repository.TriedQuizRepository;
 import yuquiz.domain.quizSeries.entity.QuizSeries;
 import yuquiz.domain.quizSeries.exception.QuizSeriesExceptionCode;
 import yuquiz.domain.quizSeries.repository.QuizSeriesRepository;
 import yuquiz.domain.series.entity.Series;
 import yuquiz.domain.series.exception.SeriesExceptionCode;
 import yuquiz.domain.series.repository.SeriesRepository;
+import yuquiz.domain.studyUser.repository.StudyUserRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,26 @@ public class QuizSeriesService {
     private final QuizSeriesRepository quizSeriesRepository;
     private final QuizRepository quizRepository;
     private final SeriesRepository seriesRepository;
+    private final TriedQuizRepository triedQuizRepository;
+    private final StudyUserRepository studyUserRepository;
+
+    private static final int QUIZ_PER_PAGE = 20;
+
+    public Page<QuizSummaryRes> getQuizzesBySeriesId(Long seriesId, Integer page, long userId) {
+        if (validateMember(seriesId, userId)) {
+            throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);
+        }
+
+        Pageable pageable = PageRequest.of(page, QUIZ_PER_PAGE);
+        Page<Quiz> quizzes = quizSeriesRepository.getQuizzesBySeriesId(seriesId, pageable, QuizSortType.DATE_DESC.getOrder());
+
+        return quizzes.map(quiz -> {
+            boolean isSolved = triedQuizRepository.getIsSolvedByUser_IdAndQuiz_Id(quiz.getId(), userId)
+                    .orElse(false);
+
+            return QuizSummaryRes.fromEntity(quiz, isSolved);
+        });
+    }
 
     @Transactional
     public void addQuiz(Long seriesId, Long quizId, Long userId) {
@@ -61,5 +88,12 @@ public class QuizSeriesService {
         return seriesRepository.findCreatorIdById(seriesId)
                 .map(creatorId -> creatorId.equals(userId))
                 .orElse(false);
+    }
+
+    private boolean validateMember(Long seriesId, Long userId) {
+
+        return seriesRepository.findStudyIdById(seriesId)
+                .map(studyId -> studyUserRepository.existsByStudy_IdAndUser_Id(studyId, userId))
+                .orElse(true);
     }
 }

--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -33,6 +33,7 @@ public class QuizSeriesService {
 
     private static final int QUIZ_PER_PAGE = 20;
 
+    @Transactional(readOnly = true)
     public Page<QuizSummaryRes> getQuizzesBySeriesId(Long seriesId, Integer page, long userId) {
         if (!validateMember(seriesId, userId)) {
             throw new CustomException(QuizSeriesExceptionCode.UNAUTHORIZED_ACTION);

--- a/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
@@ -19,6 +19,8 @@ public interface SeriesRepository extends JpaRepository<Series, Long> {
             "and (:keyword is null or s.name like %:keyword%)")
     Page<Series> findByKeywordAndStudyIsNull(@Param("keyword") String keyword, Pageable pageable);
 
+    Optional<Long> findStudyIdById(Long id);
+
     @Query("select s from Series s " +
             "where s.study.id = :study " +
             "and (:keyword is null or s.name like %:keyword%)")

--- a/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
+++ b/src/main/java/yuquiz/domain/series/repository/SeriesRepository.java
@@ -19,7 +19,8 @@ public interface SeriesRepository extends JpaRepository<Series, Long> {
             "and (:keyword is null or s.name like %:keyword%)")
     Page<Series> findByKeywordAndStudyIsNull(@Param("keyword") String keyword, Pageable pageable);
 
-    Optional<Long> findStudyIdById(Long id);
+    @Query("select s.study.id from Series s where s.id = :id")
+    Optional<Long> findStudyIdById(@Param("id") Long id);
 
     @Query("select s from Series s " +
             "where s.study.id = :study " +

--- a/src/main/java/yuquiz/domain/series/service/SeriesService.java
+++ b/src/main/java/yuquiz/domain/series/service/SeriesService.java
@@ -35,7 +35,7 @@ public class SeriesService {
 
     private final Integer SERIES_PER_PAGE = 20;
 
-    @Transactional(readOnly = true)
+    @Transactional
     public void createSeries(SeriesReq seriesReq, Long userId) {
 
         User user = userRepository.findById(userId)


### PR DESCRIPTION
## 개요
문제집 조회 시 문제집에 포함된 퀴즈 목록을 함께 주면 좋을 것 같다는 의견이 나왔습니다. 문제집 조회시 함께 주는 것 보다는 추가 api 를 만들어주면 좋을 것 같다는 의견에 만들게 되었습니다.

## 구현사항
- 문제집id를 기반으로 퀴즈 목록 조회
- 문제집에 대한 권한 검사 (문제집이 속한 스터디의 멤버가 아닌 경우 조회 불가)

## 테스트
1. 조회 성공

<img width="841" alt="스크린샷 2024-11-20 오후 8 48 54" src="https://github.com/user-attachments/assets/412dce65-90df-4c56-be8d-0e7d5375bb86">

2. 권한 없음

<img width="842" alt="스크린샷 2024-11-20 오후 8 51 58" src="https://github.com/user-attachments/assets/d3453500-acb4-4961-9125-f4b2ad28f905">
