### PR TITLE
refact: 스터디 사용자 삭제 관련 로직 수정

### DIFF
--- a/src/main/java/yuquiz/domain/study/api/StudyApi.java
+++ b/src/main/java/yuquiz/domain/study/api/StudyApi.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Min;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
@@ -14,6 +15,9 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import yuquiz.domain.post.dto.PostReq;
+import yuquiz.domain.post.dto.PostSortType;
+import yuquiz.domain.series.dto.SeriesSortType;
 import yuquiz.domain.study.dto.StudyFilter;
 import yuquiz.domain.study.dto.StudyReq;
 import yuquiz.domain.study.dto.StudySortType;
@@ -99,50 +103,44 @@ public interface StudyApi {
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
                                     {
-                                        "totalPages": 1,
-                                        "totalElements": 2,
-                                        "first": true,
-                                        "last": true,
-                                        "size": 20,
-                                        "content": [
-                                            {
-                                                "name": "임시 1",
-                                                "leaderName": "테스터111",
-                                                "maxUser": 10,
-                                                "curUser": 1,
-                                                "registerDuration": "2024-10-17T16:50:04",
-                                                "state": null
-                                            },
-                                            {
-                                                "name": "임시",
-                                                "leaderName": "테스터",
-                                                "maxUser": 100,
-                                                "curUser": 1,
-                                                "registerDuration": "2024-10-08T16:50:08",
-                                                "state": null
-                                            }
-                                        ],
-                                        "number": 0,
-                                        "sort": {
-                                            "empty": true,
-                                            "unsorted": true,
-                                            "sorted": false
-                                        },
-                                        "pageable": {
-                                            "pageNumber": 0,
-                                            "pageSize": 20,
-                                            "sort": {
-                                                "empty": true,
-                                                "unsorted": true,
-                                                "sorted": false
-                                            },
-                                            "offset": 0,
-                                            "unpaged": false,
-                                            "paged": true
-                                        },
-                                        "numberOfElements": 2,
-                                        "empty": false
-                                    }
+                                        {
+                                         "totalPages": 1,
+                                         "totalElements": 1,
+                                         "first": true,
+                                         "last": true,
+                                         "size": 20,
+                                         "content": [
+                                             {
+                                                 "id": 17,
+                                                 "name": "내 스터디 어디갔노",
+                                                 "leaderName": "dryice",
+                                                 "maxUser": 10,
+                                                 "curUser": 2,
+                                                 "registerDuration": "2024-11-23T16:08:00",
+                                                 "state": "ACTIVE"
+                                             }
+                                         ],
+                                         "number": 0,
+                                         "sort": {
+                                             "empty": true,
+                                             "unsorted": true,
+                                             "sorted": false
+                                         },
+                                         "pageable": {
+                                             "pageNumber": 0,
+                                             "pageSize": 20,
+                                             "sort": {
+                                                 "empty": true,
+                                                 "unsorted": true,
+                                                 "sorted": false
+                                             },
+                                             "offset": 0,
+                                             "unpaged": false,
+                                             "paged": true
+                                         },
+                                         "numberOfElements": 1,
+                                         "empty": false
+                                     }
                                     """)
                     }))
     })
@@ -287,6 +285,15 @@ public interface StudyApi {
                                         "message": "존재하지 않는 스터디입니다."
                                     }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "스터디 최대 인원수 초과",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 409,
+                                        "message": "스터디의 최대 인원수를 초과하였습니다."
+                                    }
+                                    """)
                     }))
     })
     ResponseEntity<?> acceptRequest(@PathVariable(value = "studyId") Long studyId,
@@ -343,6 +350,84 @@ public interface StudyApi {
                                     }
                                     """)
                     })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 사용자",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                         "status": 404,
+                                         "message": "존재하지 않는 사용자입니다."
+                                     }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "409", description = "스터디 최대 인원수 초과",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 409,
+                                        "message": "스터디의 최대 인원수를 초과하였습니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> deleteMember(@PathVariable(value = "studyId") Long studyId,
+                                   @RequestParam(value = "id") Long deleteUserId,
+                                   @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "스터디 문제집 목록 조회", description = "스터디 문제집 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스터디 문제집 목록 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                                {
+                                                    "totalPages": 1,
+                                                    "totalElements": 2,
+                                                    "first": true,
+                                                    "last": true,
+                                                    "size": 20,
+                                                    "content": [
+                                                        {
+                                                            "id": 22,
+                                                            "name": "스터디 문제집2",
+                                                            "creator": "어드민"
+                                                        },
+                                                        {
+                                                            "id": 21,
+                                                            "name": "스터디 문제집1",
+                                                            "creator": "어드민"
+                                                        }
+                                                    ],
+                                                    "number": 0,
+                                                    "sort": {
+                                                        "empty": false,
+                                                        "unsorted": false,
+                                                        "sorted": true
+                                                    },
+                                                    "pageable": {
+                                                        "pageNumber": 0,
+                                                        "pageSize": 20,
+                                                        "sort": {
+                                                            "empty": false,
+                                                            "unsorted": false,
+                                                            "sorted": true
+                                                        },
+                                                        "offset": 0,
+                                                        "unpaged": false,
+                                                        "paged": true
+                                                    },
+                                                    "numberOfElements": 2,
+                                                    "empty": false
+                                                }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "스터디원이 아님",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 스터디",
                     content = @Content(mediaType = "application/json", examples = {
                             @ExampleObject(value = """
@@ -353,7 +438,215 @@ public interface StudyApi {
                                     """)
                     }))
     })
-    ResponseEntity<?> deleteMember(@PathVariable(value = "studyId") Long studyId,
-                                   @RequestParam(value = "id") Long deleteUserId,
-                                   @AuthenticationPrincipal SecurityUserDetails userDetails);
+    ResponseEntity<?> getStudySeries(@PathVariable(value = "studyId") Long studyId,
+                                     @RequestParam(value = "sort", defaultValue = "DATE_DESC") SeriesSortType sort,
+                                     @RequestParam(value = "page", defaultValue = "0") Integer page,
+                                     @RequestParam(value = "keyword", defaultValue = "") String keyword,
+                                     @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "스터디 공지 작성", description = "스터디 공지 작성 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "스터디 공지 작성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "response": "성공적으로 생성되었습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "스터디장이 아님",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 스터디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "존재하지 않는 스터디입니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createStudyNotice(@PathVariable(value = "studyId") Long studyId,
+                                        @Valid @RequestBody PostReq postReq,
+                                        @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "스터디 게시글 생성", description = "스터디 게시글 생성 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "스터디 게시글 생성 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "response": "성공적으로 생성되었습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "스터디원이 아님",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 스터디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "존재하지 않는 스터디입니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> createStudyPost(@PathVariable(value = "studyId") Long studyId,
+                                      @Valid @RequestBody PostReq postReq,
+                                      @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "스터디 공지 목록 조회", description = "스터디 공지 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스터디 공지 목록 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "totalPages": 1,
+                                        "totalElements": 1,
+                                        "first": true,
+                                        "last": true,
+                                        "size": 20,
+                                        "content": [
+                                            {
+                                                "postId": 41,
+                                                "postTitle": "공지 테스트123",
+                                                "nickname": "어드민",
+                                                "categoryName": "스터디",
+                                                "createdAt": "2024-11-19T18:26:22.185715",
+                                                "likeCount": 0,
+                                                "viewCount": 0
+                                            }
+                                        ],
+                                        "number": 0,
+                                        "sort": {
+                                            "empty": true,
+                                            "unsorted": true,
+                                            "sorted": false
+                                        },
+                                        "pageable": {
+                                            "pageNumber": 0,
+                                            "pageSize": 20,
+                                            "sort": {
+                                                "empty": true,
+                                                "unsorted": true,
+                                                "sorted": false
+                                            },
+                                            "offset": 0,
+                                            "unpaged": false,
+                                            "paged": true
+                                        },
+                                        "numberOfElements": 1,
+                                        "empty": false
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "스터디원이 아님",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 스터디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "존재하지 않는 스터디입니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getStudyNotices(@PathVariable(value = "studyId") Long studyId,
+                                      @RequestParam(value = "keyword", required = false) String keyword,
+                                      @RequestParam(value = "sort", defaultValue = "DATE_DESC") PostSortType sort,
+                                      @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                      @AuthenticationPrincipal SecurityUserDetails userDetails);
+
+    @Operation(summary = "스터디 게시글 목록 조회", description = "스터디 게시글 목록 조회 API")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "스더티 게시글 목록 조회 성공",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "totalPages": 1,
+                                        "totalElements": 1,
+                                        "first": true,
+                                        "last": true,
+                                        "size": 20,
+                                        "content": [
+                                            {
+                                                "postId": 42,
+                                                "postTitle": "스터디 게시글 테스트",
+                                                "nickname": "어드민",
+                                                "categoryName": "스터디",
+                                                "createdAt": "2024-11-19T18:26:31.51824",
+                                                "likeCount": 0,
+                                                "viewCount": 0
+                                            }
+                                        ],
+                                        "number": 0,
+                                        "sort": {
+                                            "empty": true,
+                                            "sorted": false,
+                                            "unsorted": true
+                                        },
+                                        "numberOfElements": 1,
+                                        "pageable": {
+                                            "pageNumber": 0,
+                                            "pageSize": 20,
+                                            "sort": {
+                                                "empty": true,
+                                                "sorted": false,
+                                                "unsorted": true
+                                            },
+                                            "offset": 0,
+                                            "paged": true,
+                                            "unpaged": false
+                                        },
+                                        "empty": false
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "스터디원이 아님",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
+                    })),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 스터디",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 404,
+                                        "message": "존재하지 않는 스터디입니다."
+                                    }
+                                    """)
+                    }))
+    })
+    ResponseEntity<?> getStudyPosts(@PathVariable(value = "studyId") Long studyId,
+                                    @RequestParam(value = "keyword", required = false) String keyword,
+                                    @RequestParam(value = "sort", defaultValue = "DATE_DESC") PostSortType sort,
+                                    @RequestParam(value = "page", defaultValue = "0") @Min(0) Integer page,
+                                    @AuthenticationPrincipal SecurityUserDetails userDetails);
 }

--- a/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
+++ b/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
@@ -7,6 +7,7 @@ import yuquiz.common.exception.exceptionCode.ExceptionCode;
 public enum StudyExceptionCode implements ExceptionCode {
 
     INVALID_ID(404, "존재하지 않는 스터디입니다."),
+    INVALID_USER(404, "존재하지 않는 사용자입니다."),
     UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
     ALREADY_REGISTERED(409, "이미 가입되었습니다."),
     STUDY_FULL(409, "스터디의 최대 인원수를 초과하였습니다."),

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -202,14 +202,18 @@ public class StudyService {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
 
-        study.decreaseUser();
 
-        studyUserRepository.deleteByStudy_IdAndUser_Id(studyId, deleteId);
+        int result = studyUserRepository.deleteByStudy_IdAndUser_Id(studyId, deleteId);
+
+        if (result != 1) {
+            throw new CustomException(StudyExceptionCode.INVALID_USER);
+        }
 
         // todo : 사용자 조회 없이 처리할 방법은?
         User user = userRepository.findById(deleteId)
                 .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));
 
+        study.decreaseUser();
         studyNotification(study, user, NotificationType.STUDY_KICKED, "스터디에서 강제 퇴장 당했습니다.");
     }
 

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -18,5 +18,5 @@ public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
 
     List<StudyUser> findByStudyIdAndState(Long studyId, UserState state);
 
-    void deleteByStudy_IdAndUser_Id(Long studyId, Long userId);
+    int deleteByStudy_IdAndUser_Id(Long studyId, Long userId);
 }


### PR DESCRIPTION
## 개요
스터디 사용자 삭제 관련 로직 수정

## 구현사항
* 스터디 사용자 삭제 관련 로직 수정
  * 기존에 사용자 삭제 로직에서 사용자가 존재하는지 검증 로직이 없어서 스터디 인원수가 무한으로 감소할 수 있는 오류가 있었음
  * deleteByStudy_IdAndUser_Id 의 반환값이 1이 맞는지 확인하여 쿼리문을 따로 날리지 않고 해당 사용자가 존재했는지 파악하는 로직 추가
* 스터디 관련 Swagger 추가 작성


## 테스트
<img width="625" alt="image" src="https://github.com/user-attachments/assets/9ad72090-486c-4578-9598-59199de478bb">
