### PR TITLE
feat: 문제집 퀴즈 조회시 시도한 내역이 없는 경우 null 반환

### DIFF
--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -43,8 +43,8 @@ public class QuizSeriesService {
         Page<Quiz> quizzes = quizSeriesRepository.getQuizzesBySeriesId(seriesId, pageable, QuizSortType.DATE_DESC.getOrder());
 
         return quizzes.map(quiz -> {
-            boolean isSolved = triedQuizRepository.getIsSolvedByUser_IdAndQuiz_Id(quiz.getId(), userId)
-                    .orElse(false);
+            Boolean isSolved = triedQuizRepository.getIsSolvedByUser_IdAndQuiz_Id(quiz.getId(), userId)
+                    .orElse(null);
 
             return QuizSummaryRes.fromEntity(quiz, isSolved);
         });


### PR DESCRIPTION
## 개요
문제집 퀴즈 조회시 시도한 내역이 없는 경우 null 반환하도록 변경 (기존에는 false 반환)

## 구현사항

문제집 퀴즈 조회시 시도한 내역이 없는 경우 null 반환

## 테스트
1. 조회 성공

<img width="842" alt="image" src="https://github.com/user-attachments/assets/a5e7e030-e0eb-42e3-86c6-2bd2d784531c">

2. 권한이 없는 경우

<img width="839" alt="image" src="https://github.com/user-attachments/assets/e99e9e23-4748-4ae0-9a06-316baee6bd25">