### PR TITLE
fix: 모든 isSolved 결과가 null로 반환되는 문제 해결

### DIFF
--- a/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
+++ b/src/main/java/yuquiz/domain/quizSeries/service/QuizSeriesService.java
@@ -43,7 +43,7 @@ public class QuizSeriesService {
         Page<Quiz> quizzes = quizSeriesRepository.getQuizzesBySeriesId(seriesId, pageable, QuizSortType.DATE_DESC.getOrder());
 
         return quizzes.map(quiz -> {
-            Boolean isSolved = triedQuizRepository.getIsSolvedByUser_IdAndQuiz_Id(quiz.getId(), userId)
+            Boolean isSolved = triedQuizRepository.getIsSolvedByUser_IdAndQuiz_Id(userId, quiz.getId())
                     .orElse(null);
 
             return QuizSummaryRes.fromEntity(quiz, isSolved);


### PR DESCRIPTION
## 개요
userId와 quizId의 순서로 인해 잘못된 결과 반환 문제 해결

## 구현사항

모든 isSolved 결과가 null로 반환되는 문제 해결

## 테스트

1. 조회

<img width="836" alt="image" src="https://github.com/user-attachments/assets/6d683da8-1c21-446d-a62e-3869731d40a4">
