### PR TITLE
refeat: 카테고리 관련 로직 수정

### DIFF
--- a/src/main/java/yuquiz/domain/category/service/CategoryService.java
+++ b/src/main/java/yuquiz/domain/category/service/CategoryService.java
@@ -17,6 +17,7 @@ public class CategoryService {
     public List<CategorySummaryRes> getCategories() {
 
         return categoryRepository.findAll().stream()
+                .filter(category -> category.getId() != 3)
                 .map(CategorySummaryRes::fromEntity)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
+++ b/src/main/java/yuquiz/domain/post/repository/CustomPostRepositoryImpl.java
@@ -102,8 +102,9 @@ public class CustomPostRepositoryImpl implements CustomPostRepository {
 
     private BooleanExpression categoryEqual(Long categoryId) {
         if (categoryId == null) {
-            return null;
+            return post.category.id.ne(3L);
         }
+
         return post.category.id.eq(categoryId);
     }
 }


### PR DESCRIPTION
## 개요
카테고리 관련 로직 수정

## 구현사항
프론트 코드를 보니 카테고리 목록을 그대로 불러와서 게시물을 처리했기 때문에
기존에 스터디 사용자가 아니더라도 스터디 관련 게시물을 볼 수 있었음.
따라서 카테고리 목록을 반환할 때, 스터디 카테고리인 3번을 생략하고 보내주도록 수정함.
또한, 전체 게시물 조회에서 스터디와 관련된 게시물을 보여주지 않도록 함.
