### PR TITLE
refeat: 스터디 가입 기간 처리

### DIFF
--- a/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
+++ b/src/main/java/yuquiz/domain/study/exception/StudyExceptionCode.java
@@ -11,6 +11,7 @@ public enum StudyExceptionCode implements ExceptionCode {
     UNAUTHORIZED_ACTION(403, "권한이 없습니다."),
     ALREADY_REGISTERED(409, "이미 가입되었습니다."),
     STUDY_FULL(409, "스터디의 최대 인원수를 초과하였습니다."),
+    EXPIRED_SIGNUP_PERIOD(403, "스터디 가입 기간이 지났습니다."),
     REQUEST_NOT_EXIST(404, "존재하지 않는 가입 신청입니다.");
 
 

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -42,6 +42,7 @@ import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
@@ -129,6 +130,10 @@ public class StudyService {
 
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
+
+        if (study.getRegisterDuration().isBefore(LocalDateTime.now())) {
+            throw new CustomException(StudyExceptionCode.EXPIRED_SIGNUP_PERIOD);
+        }
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserExceptionCode.INVALID_USERID));


### PR DESCRIPTION
## 개요
스터디 가입 기간 처리 로직 추가

## 구현사항
스터디 가입 시 가입 기간이 지나도 신청할 수 있었던 오류가 있었음
가입 기간을 확인하여 가입 기간이 지났으면 신청할 수 없도록 수정함.

## 테스트
<img width="675" alt="image" src="https://github.com/user-attachments/assets/b1f2c77a-0352-4f59-b5d6-4ba9accc188b">
