### PR TITLE
feat: 학과 목록 api 구현

### DIFF
--- a/src/main/java/yuquiz/config/security/SecurityConfig.java
+++ b/src/main/java/yuquiz/config/security/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig {
     private static final String[] PUBLIC_ENDPOINTS = {
             "/api/v1/auth/**", "/swagger-resources/**", "/swagger-ui/**",
             "/v3/api-docs/**", "/webjars/**", "/error", "/api/v1/users/verify-username",
-            "/api/v1/users/verify-nickname", "/api/v1/users/email/**", "/ws/**"
+            "/api/v1/users/verify-nickname", "/api/v1/users/email/**", "/ws/**", "/api/v1/majors"
     };
     private static final String[] ADMIN_ENDPOINTS = {"/api/v1/admin/**"};
 

--- a/src/main/java/yuquiz/domain/major/controller/MajorController.java
+++ b/src/main/java/yuquiz/domain/major/controller/MajorController.java
@@ -1,0 +1,21 @@
+package yuquiz.domain.major.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import yuquiz.domain.major.service.MajorService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/majors")
+public class MajorController {
+    private final MajorService majorService;
+
+    @GetMapping()
+    public ResponseEntity<?> getMajors() {
+        return ResponseEntity.status(HttpStatus.OK).body(majorService.getMajors());
+    }
+}

--- a/src/main/java/yuquiz/domain/major/dto/MajorRes.java
+++ b/src/main/java/yuquiz/domain/major/dto/MajorRes.java
@@ -1,0 +1,12 @@
+package yuquiz.domain.major.dto;
+
+import yuquiz.domain.major.entity.Major;
+
+public record MajorRes(
+        Long id,
+        String name
+) {
+    public static MajorRes fromEntity(Major major) {
+        return new MajorRes(major.getId(), major.getMajorName());
+    }
+}

--- a/src/main/java/yuquiz/domain/major/service/MajorService.java
+++ b/src/main/java/yuquiz/domain/major/service/MajorService.java
@@ -1,0 +1,21 @@
+package yuquiz.domain.major.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yuquiz.domain.major.dto.MajorRes;
+import yuquiz.domain.major.entity.Major;
+import yuquiz.domain.major.repository.MajorRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class MajorService {
+    private final MajorRepository majorRepository;
+
+    public List<MajorRes> getMajors() {
+        List<Major> majors = majorRepository.findAll();
+
+        return majors.stream().map(MajorRes::fromEntity).toList();
+    }
+}


### PR DESCRIPTION
## 개요
학과 목록 api 구현

## 구현사항
<img width="426" alt="image" src="https://github.com/user-attachments/assets/fd4a1322-5170-4eab-8bb6-1535c460bed2">

회원가입 화면에서 학과를 선택하기 위한 학과 목록 api를 구현하였습니다.
회원가입 시에 사용할 수 있도록 권한이 없더라도 접근할 수 있도록 하였습니다.

## 테스트
<img width="525" alt="image" src="https://github.com/user-attachments/assets/1e744a8f-4e0d-43b9-98f3-46fab8b27997">
