### PR TITLE
refact: 스터디 조회 시 사용자 상태 필드 추가

### DIFF
--- a/src/main/java/yuquiz/domain/study/dto/StudyRes.java
+++ b/src/main/java/yuquiz/domain/study/dto/StudyRes.java
@@ -3,6 +3,7 @@ package yuquiz.domain.study.dto;
 import yuquiz.domain.study.entity.Study;
 import yuquiz.domain.study.entity.StudyState;
 import yuquiz.domain.studyUser.entity.StudyRole;
+import yuquiz.domain.studyUser.entity.UserState;
 
 import java.time.LocalDateTime;
 
@@ -16,9 +17,10 @@ public record StudyRes(
         Integer curUser,
         StudyState state,
         boolean isMember,
-        StudyRole role
+        StudyRole role,
+        UserState userState
 ) {
-    public static StudyRes fromEntity(Study study, boolean isMember, StudyRole role) {
+    public static StudyRes fromEntity(Study study, boolean isMember, StudyRole role, UserState userState) {
         return new StudyRes(
                 study.getId(),
                 study.getChatRoom().getId(),
@@ -29,7 +31,8 @@ public record StudyRes(
                 study.getCurrentUser(),
                 study.getState(),
                 isMember,
-                role
+                role,
+                userState
         );
     }
 }

--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -117,8 +117,8 @@ public class StudyService {
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
 
         return studyUserRepository.findStudyUserByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)
-                .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole()))
-                .orElseGet(() -> StudyRes.fromEntity(study, false, null));
+                .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole(), studyUser.getState()))
+                .orElseGet(() -> StudyRes.fromEntity(study, false, null, null));
     }
 
     @Transactional
@@ -233,17 +233,17 @@ public class StudyService {
 
     @Transactional
     public void createStudyPost(PostReq postReq, Long userId, Long studyId, boolean isNotice) {
-      boolean isAuthorized;
-      
-      if (isNotice) {
-          isAuthorized = validateLeader(studyId, userId);
-      } else {
-          isAuthorized = studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED);
-      }
-      
-      if (!isAuthorized) {
-          throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
-      }
+        boolean isAuthorized;
+
+        if (isNotice) {
+            isAuthorized = validateLeader(studyId, userId);
+        } else {
+            isAuthorized = studyUserRepository.existsByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED);
+        }
+
+        if (!isAuthorized) {
+            throw new CustomException(StudyExceptionCode.UNAUTHORIZED_ACTION);
+        }
 
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
@@ -267,7 +267,7 @@ public class StudyService {
 
         Pageable pageable = PageRequest.of(page, POST_PER_PAGE);
 
-        Page<Post> posts = postRepository.getPostsByStudy(studyId, type, keyword,3L, pageable, sort);
+        Page<Post> posts = postRepository.getPostsByStudy(studyId, type, keyword, 3L, pageable, sort);
 
         return posts.map(PostSummaryRes::fromEntity);
     }


### PR DESCRIPTION
## 개요
스터디 조회 시 사용자 상태 필드 추가

## 구현사항
* 스터디 조회 시 사용자의 가입 상태 필드를 추가하였습니다.
  * 프론트에서 사용자의 중복 신청을 막기 위해

## 테스트
<img width="628" alt="image" src="https://github.com/user-attachments/assets/ada6c6ec-2997-4693-9c13-28e7f445de84">
