### PR TITLE
refact: 스터디 조회 시 사용자 상태 오류 수정

### DIFF
--- a/src/main/java/yuquiz/domain/study/service/StudyService.java
+++ b/src/main/java/yuquiz/domain/study/service/StudyService.java
@@ -116,7 +116,7 @@ public class StudyService {
         Study study = studyRepository.findById(studyId)
                 .orElseThrow(() -> new CustomException(StudyExceptionCode.INVALID_ID));
 
-        return studyUserRepository.findStudyUserByStudy_IdAndUser_IdAndState(studyId, userId, UserState.REGISTERED)
+        return studyUserRepository.findStudyUserByStudy_IdAndUser_Id(studyId, userId)
                 .map(studyUser -> StudyRes.fromEntity(study, true, studyUser.getRole(), studyUser.getState()))
                 .orElseGet(() -> StudyRes.fromEntity(study, false, null, null));
     }

--- a/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
+++ b/src/main/java/yuquiz/domain/studyUser/repository/StudyUserRepository.java
@@ -16,6 +16,8 @@ public interface StudyUserRepository extends JpaRepository<StudyUser, Long> {
 
     Optional<StudyUser> findStudyUserByStudy_IdAndUser_IdAndState(Long studyId, Long userId, UserState state);
 
+    Optional<StudyUser> findStudyUserByStudy_IdAndUser_Id(Long studyId, Long userId);
+
     List<StudyUser> findByStudyIdAndState(Long studyId, UserState state);
 
     int deleteByStudy_IdAndUser_Id(Long studyId, Long userId);


### PR DESCRIPTION
## 개요
스터디 조회 시 사용자 상태 오류 수정

## 구현사항
기존에 스터디 조회 로직이 사용자의 상태가 `REGISTERED`인 상태인 `StudyUser`만 가져와서 가입 대기중인 사용자의 상태를 불러오지 못함.
따라서, 상태에 관계없이 `StudyUser`를 불러오는 `findStudyUserByStudy_IdAndUser_Id`를 구현하여 `PENDING` 상태의 사용자도 불러올 수 있게함

## 테스트
<img width="394" alt="image" src="https://github.com/user-attachments/assets/7515b1e7-14a8-443c-baf8-cb26d8a63c9d">
