### PR TITLE
refact: 퀴즈 필드 길이 수정

### DIFF
--- a/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
+++ b/src/main/java/yuquiz/domain/quiz/entity/Quiz.java
@@ -34,10 +34,11 @@ public class Quiz extends BaseTimeEntity {
     private String question;
 
     @Convert(converter = StringListConverter.class)
+    @Column(name = "choices", length = 500)
     private List<String> choices;
 
     @Convert(converter = StringListConverter.class)
-    @Column(name = "quiz_imgs")
+    @Column(name = "quiz_imgs", length = 500)
     private List<String> quizImgs;
 
     @NotNull


### PR DESCRIPTION
## 개요
퀴즈 필드 길이 수정

## 구현사항
이미지와 선지에 해당하는 필드의 길이 수정

## 기타
전에 mysql 워크벤치를 사용해서 길이를 늘렸는데
생각해보니 서버를 새로 시작할때마다 필드의 속성이 수정되서
엔티티 자체의 필드 속성값을 수정해주었습니다..
