### PR TITLE
fix: 관리자만 공지게시판에 글 등록이 가능하도록 변경

### DIFF
--- a/src/main/java/yuquiz/domain/post/api/PostApi.java
+++ b/src/main/java/yuquiz/domain/post/api/PostApi.java
@@ -39,6 +39,15 @@ public interface PostApi {
                                         "categoryId": "카테고리는 필수 입력입니다."
                                     }
                                     """)
+                    })),
+            @ApiResponse(responseCode = "403", description = "권한 없음",
+                    content = @Content(mediaType = "application/json", examples = {
+                            @ExampleObject(value = """
+                                    {
+                                        "status": 403,
+                                        "message": "권한이 없습니다."
+                                    }
+                                    """)
                     }))
     })
     ResponseEntity<?> createPost(@Valid @RequestBody PostReq postReq,

--- a/src/main/java/yuquiz/domain/post/service/PostService.java
+++ b/src/main/java/yuquiz/domain/post/service/PostService.java
@@ -19,6 +19,7 @@ import yuquiz.domain.post.dto.PostSummaryRes;
 import yuquiz.domain.post.entity.Post;
 import yuquiz.domain.post.exception.PostExceptionCode;
 import yuquiz.domain.post.repository.PostRepository;
+import yuquiz.domain.user.entity.Role;
 import yuquiz.domain.user.entity.User;
 import yuquiz.domain.user.exception.UserExceptionCode;
 import yuquiz.domain.user.repository.UserRepository;
@@ -33,6 +34,7 @@ public class PostService {
     private final LikedPostRepository likedPostRepository;
 
     private final Integer POST_PER_PAGE = 20;
+    private final String ANNOUNCEMENTS = "공지게시판";
 
     @Transactional
     public Post createPost(PostReq postReq, Long userId) {
@@ -42,6 +44,10 @@ public class PostService {
 
         Category category = categoryRepository.findById(postReq.categoryId())
                 .orElseThrow(() -> new CustomException(CategoryExceptionCode.INVALID_ID));
+
+        if (!user.getRole().equals(Role.ADMIN) && category.getCategoryName().equals(ANNOUNCEMENTS)) {
+            throw new CustomException(PostExceptionCode.UNAUTHORIZED_ACTION);
+        }
 
         Post post = postReq.toEntity(user, category);
         return postRepository.save(post);


### PR DESCRIPTION
## 개요

관리자가 아닌 경우에도 공지게시판에 글 등록이 가능한 오류 해결

## 구현사항

- 관리자만 공지게시판에 글 등록이 가능하도록 변경
- Swagger 업데이트

## 테스트

<img width="843" alt="스크린샷 2024-12-07 오후 1 42 23" src="https://github.com/user-attachments/assets/f03cecba-f1bb-44b2-abc2-1f28c574107d">

